### PR TITLE
Fix terminal resizing via virtio-console

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ This is a Nix flake that runs coding agents inside QEMU microVMs with hardware-l
 
 **Host side (`lib/mkRunner.nix`):** A `writeShellApplication` that parses CLI args at runtime, writes env vars and tool args to a temp dir, sets up 9p virtfs mounts, optionally creates a store disk image, and launches QEMU with direct kernel boot. On NixOS hosts, `/run/current-system/sw` and `/etc/profiles/per-user/$USER` are auto-mounted so host packages are available in the guest.
 
-**Guest side (`guests/common.nix` + `guests/claude.nix`):** Minimal NixOS. Two systemd services: `llmjail-mounts` parses kernel cmdline (`llmjail.mounts=tag:path:mode,...`) to mount user directories via 9p, then `llmjail-tool` runs the actual tool on `/dev/ttyS0`. `ExecStopPost` powers off the VM when the tool exits.
+**Guest side (`guests/common.nix` + `guests/claude.nix`):** Minimal NixOS. Two systemd services: `llmjail-mounts` parses kernel cmdline (`llmjail.mounts=tag:path:mode,...`) to mount user directories via 9p, then `llmjail-tool` runs the actual tool on `/dev/hvc0` (virtio-console). `ExecStopPost` powers off the VM when the tool exits. Terminal resize is handled by virtio-console with patches from `lib/qemuOverlay.nix` (not yet upstream in QEMU).
 
 **Adding a new tool:** Add an entry to `tools.nix` pointing to a new guest module under `guests/`. The guest module imports `common.nix` and overrides `systemd.services.llmjail-tool.serviceConfig.ExecStart`.
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,16 +7,31 @@
     codex-cli-nix.url = "github:sadjow/codex-cli-nix";
   };
 
-  outputs = { self, nixpkgs, claude-code-nix, codex-cli-nix, ... }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      claude-code-nix,
+      codex-cli-nix,
+      ...
+    }:
     let
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
       tools = import ./tools.nix;
+      qemuOverlay = import ./lib/qemuOverlay.nix;
 
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems f;
 
-      mkTool = system: toolName: toolDef:
+      mkTool =
+        system: toolName: toolDef:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ qemuOverlay ];
+          };
           claude-code = claude-code-nix.packages.${system}.default;
           codex-cli = codex-cli-nix.packages.${system}.default;
 
@@ -31,21 +46,23 @@
             name = toolName;
             toolDefaults = toolDef.defaults;
           };
-        in runner;
+        in
+        runner;
 
-    in {
-      packages = forAllSystems (system:
-        nixpkgs.lib.mapAttrs (name: def: mkTool system name def) tools
-      );
+    in
+    {
+      packages = forAllSystems (system: nixpkgs.lib.mapAttrs (name: def: mkTool system name def) tools);
 
-      apps = forAllSystems (system:
+      apps = forAllSystems (
+        system:
         nixpkgs.lib.mapAttrs (name: _: {
           type = "app";
           program = "${self.packages.${system}.${name}}/bin/llm-jail-${name}";
         }) tools
       );
 
-      checks = forAllSystems (system:
+      checks = forAllSystems (
+        system:
         import ./tests {
           inherit nixpkgs;
           pkgs = nixpkgs.legacyPackages.${system};

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -16,10 +16,10 @@
   config = {
     # ── Boot ──────────────────────────────────────────────────────────────
     boot.loader.grub.enable = false;
-    boot.kernelParams = [ "console=ttyS1" ];
+    boot.kernelParams = [ "console=ttyS0" ];
     boot.initrd.availableKernelModules = [
       "9p" "9pnet_virtio"
-      "virtio_pci" "virtio_blk" "virtio_net" "virtio_rng"
+      "virtio_pci" "virtio_blk" "virtio_net" "virtio_rng" "virtio_console"
       "overlay"
     ];
     boot.kernelModules = [ "nf_tables" ];
@@ -313,11 +313,6 @@
           done < /llmjail-env/tool-args
         fi
 
-        # Apply terminal dimensions to serial TTY so TUI apps render correctly
-        if [ -n "''${COLUMNS:-}" ] && [ -n "''${LINES:-}" ]; then
-          stty cols "$COLUMNS" rows "$LINES" 2>/dev/null || true
-        fi
-
         cd /workspace
         exec ${config.llmjail.toolBinary} "''${ARGS[@]}"
       '';
@@ -334,7 +329,7 @@
         StandardInput = "tty";
         StandardOutput = "tty";
         StandardError = "tty";
-        TTYPath = "/dev/ttyS0";
+        TTYPath = "/dev/hvc0";
         TTYReset = true;
         TTYVHangup = false;
         ExecStart = "${launcher}";
@@ -346,6 +341,7 @@
     # No getty on serial — tool service owns the TTY
     systemd.services."serial-getty@ttyS0".enable = false;
     systemd.services."serial-getty@ttyS1".enable = false;
+    systemd.services."serial-getty@hvc0".enable = false;
     systemd.services."getty@tty1".enable = false;
 
     documentation.enable = false;

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -93,7 +93,8 @@ pkgs.writeShellApplication {
       # Forward AWS variables
       env | grep '^AWS_' || true
 
-      # Forward terminal type and dimensions so TUI apps render correctly
+      # Forward terminal type so TUI apps render correctly
+      # Terminal dimensions are propagated dynamically via virtio-console resize.
       for var in TERM COLORTERM; do
         if [ -n "''${!var:-}" ]; then
           echo "$var=\"''${!var}\""
@@ -101,10 +102,6 @@ pkgs.writeShellApplication {
       done
       if [ -z "''${TERM:-}" ]; then
         echo "TERM=\"xterm-256color\""
-      fi
-      if STTY_SIZE=$(stty size 2>/dev/null); then
-        echo "LINES=''${STTY_SIZE%% *}"
-        echo "COLUMNS=''${STTY_SIZE##* }"
       fi
 
       echo "HOME=/home/user"
@@ -235,7 +232,7 @@ pkgs.writeShellApplication {
     done
 
     # ── Kernel command line ───────────────────────────────────────────
-    KERNEL_PARAMS="$(cat ${toplevel}/kernel-params) init=${toplevel}/init console=ttyS1 llmjail.mounts=$MOUNT_CMDLINE"
+    KERNEL_PARAMS="$(cat ${toplevel}/kernel-params) init=${toplevel}/init console=ttyS0 llmjail.mounts=$MOUNT_CMDLINE"
 
     if [ "$STORE_DISK" -gt 0 ]; then
       KERNEL_PARAMS="$KERNEL_PARAMS llmjail.store_disk=1"
@@ -271,7 +268,10 @@ pkgs.writeShellApplication {
       -initrd ${toplevel}/initrd \
       -append "$KERNEL_PARAMS" \
       -nographic \
-      -serial mon:stdio \
+      -chardev stdio,id=char0,mux=on,signal=off \
+      -device virtio-serial-pci \
+      -device virtconsole,chardev=char0 \
+      -mon chardev=char0 \
       -serial file:"$RUNDIR/kernel.log" \
       -no-reboot \
       -device virtio-rng-pci \

--- a/lib/qemu-patches/0001-console-resize.patch
+++ b/lib/qemu-patches/0001-console-resize.patch
@@ -1,0 +1,78 @@
+From: Szymon Lukasz <noh4hss@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:44 +0100
+Subject: [PATCH] chardev: add cols, rows fields
+
+These fields should be interpreted as the size of the terminal connected
+to a given chardev.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+[Filip: CharBackend -> CharFrontend]
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+---
+ chardev/char-fe.c         | 13 +++++++++++++
+ include/chardev/char-fe.h | 10 ++++++++++
+ include/chardev/char.h    |  1 +
+ 3 files changed, 24 insertions(+)
+
+diff --git a/chardev/char-fe.c b/chardev/char-fe.c
+index 34b83fc1c4..a3bb1071b3 100644
+--- a/chardev/char-fe.c
++++ b/chardev/char-fe.c
+@@ -329,6 +329,19 @@ void qemu_chr_fe_set_echo(CharFrontend *c, bool echo)
+     }
+ }
+ 
++void qemu_chr_fe_get_winsize(CharFrontend *c, uint16_t *cols, uint16_t *rows)
++{
++    Chardev *chr = c->chr;
++
++    if (chr) {
++        *cols = chr->cols;
++        *rows = chr->rows;
++    } else {
++        *cols = 0;
++        *rows = 0;
++    }
++}
++
+ void qemu_chr_fe_set_open(CharFrontend *c, bool is_open)
+ {
+     Chardev *chr = c->chr;
+diff --git a/include/chardev/char-fe.h b/include/chardev/char-fe.h
+index 5f8a6df17d..53b8d2a1dc 100644
+--- a/include/chardev/char-fe.h
++++ b/include/chardev/char-fe.h
+@@ -157,6 +157,16 @@ int qemu_chr_fe_wait_connected(CharFrontend *c, Error **errp);
+  */
+ void qemu_chr_fe_set_echo(CharFrontend *c, bool echo);
+ 
++/**
++ * qemu_chr_fe_get_winsize:
++ * @cols: the address for storing columns
++ * @rows: the address for storing rows
++ *
++ * Get the size of the terminal connected to the chardev backend.
++ * Returns *cols = *rows = 0, if no associated Chardev.
++ */
++void qemu_chr_fe_get_winsize(CharFrontend *c, uint16_t *cols, uint16_t *rows);
++
+ /**
+  * qemu_chr_fe_set_open:
+  * @c: a CharFrontend
+diff --git a/include/chardev/char.h b/include/chardev/char.h
+index 192cad67d4..237238e5a0 100644
+--- a/include/chardev/char.h
++++ b/include/chardev/char.h
+@@ -65,6 +65,7 @@ struct Chardev {
+     char *filename;
+     int logfd;
+     int be_open;
++    uint16_t cols, rows;
+     /* used to coordinate the chardev-change special-case: */
+     bool handover_yank_instance;
+     GSource *gsource;
+ 
+-- 
+2.52.0
+ 

--- a/lib/qemu-patches/0002-console-resize.patch
+++ b/lib/qemu-patches/0002-console-resize.patch
@@ -1,0 +1,241 @@
+From: Szymon Lukasz <noh4hss@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:45 +0100
+Subject: [PATCH] chardev: add CHR_EVENT_RESIZE
+
+Add a new chardev event, CHR_EVENT_RESIZE, which a backend should
+trigger if it detects the size of the connected terminal changed.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+[Filip: add note that only the focused frontend gets the event]
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+---
+ backends/cryptodev-vhost-user.c | 1 +
+ chardev/char.c                  | 1 +
+ hw/block/vhost-user-blk.c       | 1 +
+ hw/char/terminal3270.c          | 1 +
+ hw/char/virtio-console.c        | 1 +
+ hw/ipmi/ipmi_bmc_extern.c       | 1 +
+ hw/scsi/vhost-user-scsi.c       | 1 +
+ hw/usb/ccid-card-passthru.c     | 1 +
+ hw/usb/dev-serial.c             | 1 +
+ hw/usb/redirect.c               | 1 +
+ hw/virtio/vhost-user-base.c     | 1 +
+ hw/virtio/vhost-user-scmi.c     | 1 +
+ include/chardev/char.h          | 6 ++++++
+ monitor/hmp.c                   | 1 +
+ monitor/qmp.c                   | 1 +
+ net/passt.c                     | 1 +
+ net/vhost-user.c                | 1 +
+ 17 files changed, 22 insertions(+)
+
+diff --git a/backends/cryptodev-vhost-user.c b/backends/cryptodev-vhost-user.c
+index cc478d9902..36564d4307 100644
+--- a/backends/cryptodev-vhost-user.c
++++ b/backends/cryptodev-vhost-user.c
+@@ -173,6 +173,7 @@ static void cryptodev_vhost_user_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/chardev/char.c b/chardev/char.c
+index 3e432195a5..0f493d793f 100644
+--- a/chardev/char.c
++++ b/chardev/char.c
+@@ -75,6 +75,7 @@ void qemu_chr_be_event(Chardev *s, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/block/vhost-user-blk.c b/hw/block/vhost-user-blk.c
+index 4d81d2dc34..a460d6ed33 100644
+--- a/hw/block/vhost-user-blk.c
++++ b/hw/block/vhost-user-blk.c
+@@ -412,6 +412,7 @@ static void vhost_user_blk_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/char/terminal3270.c b/hw/char/terminal3270.c
+index 1d857bad9b..c212fd1aac 100644
+--- a/hw/char/terminal3270.c
++++ b/hw/char/terminal3270.c
+@@ -172,6 +172,7 @@ static void chr_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/char/virtio-console.c b/hw/char/virtio-console.c
+index 25db0f019b..dcfe5830f9 100644
+--- a/hw/char/virtio-console.c
++++ b/hw/char/virtio-console.c
+@@ -168,6 +168,7 @@ static void chr_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/ipmi/ipmi_bmc_extern.c b/hw/ipmi/ipmi_bmc_extern.c
+index fa08ed6c21..bd7c61b2d2 100644
+--- a/hw/ipmi/ipmi_bmc_extern.c
++++ b/hw/ipmi/ipmi_bmc_extern.c
+@@ -436,6 +436,7 @@ static void chr_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/scsi/vhost-user-scsi.c b/hw/scsi/vhost-user-scsi.c
+index 3612897d4b..5601097bc9 100644
+--- a/hw/scsi/vhost-user-scsi.c
++++ b/hw/scsi/vhost-user-scsi.c
+@@ -226,6 +226,7 @@ static void vhost_user_scsi_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/usb/ccid-card-passthru.c b/hw/usb/ccid-card-passthru.c
+index 5ab7855272..3f4052ec82 100644
+--- a/hw/usb/ccid-card-passthru.c
++++ b/hw/usb/ccid-card-passthru.c
+@@ -323,6 +323,7 @@ static void ccid_card_vscard_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
+     case CHR_EVENT_CLOSED:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/usb/dev-serial.c b/hw/usb/dev-serial.c
+index b238cb7937..98d2abbd56 100644
+--- a/hw/usb/dev-serial.c
++++ b/hw/usb/dev-serial.c
+@@ -576,6 +576,7 @@ static void usb_serial_event(void *opaque, QEMUChrEvent event)
+         break;
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/usb/redirect.c b/hw/usb/redirect.c
+index fda5bbca67..34ab8339e1 100644
+--- a/hw/usb/redirect.c
++++ b/hw/usb/redirect.c
+@@ -1390,6 +1390,7 @@ static void usbredir_chardev_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/virtio/vhost-user-base.c b/hw/virtio/vhost-user-base.c
+index 01ab9ca56b..fd3a9d6265 100644
+--- a/hw/virtio/vhost-user-base.c
++++ b/hw/virtio/vhost-user-base.c
+@@ -267,6 +267,7 @@ static void vub_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/hw/virtio/vhost-user-scmi.c b/hw/virtio/vhost-user-scmi.c
+index f9264c4374..180787ec6d 100644
+--- a/hw/virtio/vhost-user-scmi.c
++++ b/hw/virtio/vhost-user-scmi.c
+@@ -214,6 +214,7 @@ static void vu_scmi_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/include/chardev/char.h b/include/chardev/char.h
+index 237238e5a0..2c139f07dc 100644
+--- a/include/chardev/char.h
++++ b/include/chardev/char.h
+@@ -22,6 +22,12 @@ typedef enum {
+     CHR_EVENT_OPENED, /* new connection established */
+     CHR_EVENT_MUX_IN, /* mux-focus was set to this terminal */
+     CHR_EVENT_MUX_OUT, /* mux-focus will move on */
++    CHR_EVENT_RESIZE, /*
++                       * the size of the terminal connected to
++                       * the chardev has changed.  NOTE: this event is only
++                       * sent to the focused frontend, so you should also
++                       * update the size on receiving CHR_EVENT_MUX_IN.
++                       */
+     CHR_EVENT_CLOSED /* connection closed.  NOTE: currently this event
+                       * is only bound to the read port of the chardev.
+                       * Normally the read port and write port of a
+diff --git a/monitor/hmp.c b/monitor/hmp.c
+index 4caafbc714..dea912092d 100644
+--- a/monitor/hmp.c
++++ b/monitor/hmp.c
+@@ -1445,6 +1445,7 @@ static void monitor_event(void *opaque, QEMUChrEvent event)
+         break;
+ 
+     case CHR_EVENT_BREAK:
++    case CHR_EVENT_RESIZE:
+         /* Ignored */
+         break;
+     }
+diff --git a/monitor/qmp.c b/monitor/qmp.c
+index 687019811f..3d5ab8ff4f 100644
+--- a/monitor/qmp.c
++++ b/monitor/qmp.c
+@@ -486,6 +486,7 @@ static void monitor_qmp_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/net/passt.c b/net/passt.c
+index 9ed811a514..a3e239f306 100644
+--- a/net/passt.c
++++ b/net/passt.c
+@@ -421,6 +421,7 @@ static void passt_vhost_user_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+diff --git a/net/vhost-user.c b/net/vhost-user.c
+index a4bb49bbcf..0b8df2ee30 100644
+--- a/net/vhost-user.c
++++ b/net/vhost-user.c
+@@ -367,6 +367,7 @@ static void net_vhost_user_event(void *opaque, QEMUChrEvent event)
+     case CHR_EVENT_BREAK:
+     case CHR_EVENT_MUX_IN:
+     case CHR_EVENT_MUX_OUT:
++    case CHR_EVENT_RESIZE:
+         /* Ignore */
+         break;
+     }
+ 
+-- 

--- a/lib/qemu-patches/0003-console-resize.patch
+++ b/lib/qemu-patches/0003-console-resize.patch
@@ -1,0 +1,54 @@
+From: Szymon Lukasz <noh4hss@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:46 +0100
+Subject: [PATCH] chardev: add qemu_chr_resize()
+
+This function should be called whenever we learn about a new size of
+the terminal connected to a chardev.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+---
+ chardev/char.c         | 11 +++++++++++
+ include/chardev/char.h |  2 ++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/chardev/char.c b/chardev/char.c
+index 0f493d793f..f3c6a12c99 100644
+--- a/chardev/char.c
++++ b/chardev/char.c
+@@ -351,6 +351,17 @@ int qemu_chr_wait_connected(Chardev *chr, Error **errp)
+     return 0;
+ }
+ 
++void qemu_chr_resize(Chardev *chr, uint16_t cols, uint16_t rows)
++{
++    if (cols != chr->cols || rows != chr->rows) {
++        chr->cols = cols;
++        chr->rows = rows;
++        if (chr->be_open) {
++            qemu_chr_be_event(chr, CHR_EVENT_RESIZE);
++        }
++    }
++}
++
+ QemuOpts *qemu_chr_parse_compat(const char *label, const char *filename,
+                                 bool permit_mux_mon)
+ {
+diff --git a/include/chardev/char.h b/include/chardev/char.h
+index 2c139f07dc..8e998ed3c1 100644
+--- a/include/chardev/char.h
++++ b/include/chardev/char.h
+@@ -234,6 +234,8 @@ int qemu_chr_write(Chardev *s, const uint8_t *buf, int len, bool write_all);
+ #define qemu_chr_write_all(s, buf, len) qemu_chr_write(s, buf, len, true)
+ int qemu_chr_wait_connected(Chardev *chr, Error **errp);
+ 
++void qemu_chr_resize(Chardev *chr, uint16_t cols, uint16_t rows);
++
+ #define TYPE_CHARDEV "chardev"
+ OBJECT_DECLARE_TYPE(Chardev, ChardevClass, CHARDEV)
+ 
+ 
+-- 
+2.52.0
+ 

--- a/lib/qemu-patches/0004-console-resize.patch
+++ b/lib/qemu-patches/0004-console-resize.patch
@@ -1,0 +1,60 @@
+From: Szymon Lukasz <noh4hss@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:47 +0100
+Subject: [PATCH] char-mux: add support for the terminal size
+
+The terminal size of a mux chardev should be the same as the real
+chardev, so listen for CHR_EVENT_RESIZE to be up to date.
+
+We forward CHR_EVENT_RESIZE only to the focused frontend. This means
+frontends should update their view of the terminal size on
+receiving CHR_EVENT_MUX_IN.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+---
+ chardev/char-mux.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/chardev/char-mux.c b/chardev/char-mux.c
+index db9e89f441..b23fedbcfe 100644
+--- a/chardev/char-mux.c
++++ b/chardev/char-mux.c
+@@ -264,9 +264,24 @@ void mux_chr_send_all_event(Chardev *chr, QEMUChrEvent event)
+     }
+ }
+ 
++static void mux_update_winsize(Chardev *chr)
++{
++    MuxChardev *d = MUX_CHARDEV(chr);
++    uint16_t cols, rows;
++
++    qemu_chr_fe_get_winsize(&d->chr, &cols, &rows);
++    qemu_chr_resize(chr, cols, rows);
++}
++
+ static void mux_chr_event(void *opaque, QEMUChrEvent event)
+ {
+-    mux_chr_send_all_event(CHARDEV(opaque), event);
++    Chardev *chr = CHARDEV(opaque);
++
++    if (event == CHR_EVENT_RESIZE) {
++        mux_update_winsize(chr);
++    } else {
++        mux_chr_send_all_event(chr, event);
++    }
+ }
+ 
+ static GSource *mux_chr_add_watch(Chardev *s, GIOCondition cond)
+@@ -382,6 +397,7 @@ static void qemu_chr_open_mux(Chardev *chr,
+      */
+     *be_opened = muxes_opened;
+     qemu_chr_fe_init(&d->chr, drv, errp);
++    mux_update_winsize(chr);
+ }
+
+ static void qemu_chr_parse_mux(QemuOpts *opts, ChardevBackend *backend,
+ 
+-- 
+2.52.0
+ 

--- a/lib/qemu-patches/0005-console-resize.patch
+++ b/lib/qemu-patches/0005-console-resize.patch
@@ -1,0 +1,116 @@
+From: Szymon Lukasz <noh4hss@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:48 +0100
+Subject: [PATCH] main-loop: change the handling of SIGWINCH
+
+Block SIGWINCH, so it is delivered only via signalfd.
+Install a handler that uses NotifierList to tell
+interested parties about SIGWINCH delivery.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+---
+ include/qemu/main-loop.h |  4 ++++
+ ui/curses.c              | 11 ++++++-----
+ util/main-loop.c         | 21 +++++++++++++++++++++
+ 3 files changed, 31 insertions(+), 5 deletions(-)
+
+diff --git a/include/qemu/main-loop.h b/include/qemu/main-loop.h
+index 8c1241a2c1..ff41346b0b 100644
+--- a/include/qemu/main-loop.h
++++ b/include/qemu/main-loop.h
+@@ -449,4 +449,8 @@ typedef struct MainLoopPoll {
+ void main_loop_poll_add_notifier(Notifier *notify);
+ void main_loop_poll_remove_notifier(Notifier *notify);
+ 
++#ifndef _WIN32
++void sigwinch_add_notifier(Notifier *n);
++#endif
++
+ #endif
+diff --git a/ui/curses.c b/ui/curses.c
+index 161f78c35c..d1b308d5f8 100644
+--- a/ui/curses.c
++++ b/ui/curses.c
+@@ -33,6 +33,7 @@
+ #include <iconv.h>
+ 
+ #include "qapi/error.h"
++#include "qemu/main-loop.h"
+ #include "qemu/module.h"
+ #include "ui/console.h"
+ #include "ui/input.h"
+@@ -149,7 +150,7 @@ static void curses_resize(DisplayChangeListener *dcl,
+ }
+ 
+ #if !defined(_WIN32) && defined(SIGWINCH) && defined(KEY_RESIZE)
+-static volatile sig_atomic_t got_sigwinch;
++static bool got_sigwinch;
+ static void curses_winch_check(void)
+ {
+     struct winsize {
+@@ -172,17 +173,17 @@ static void curses_winch_check(void)
+     invalidate = 1;
+ }
+ 
+-static void curses_winch_handler(int signum)
++static void curses_winch_handler(Notifier *n, void *data)
+ {
+     got_sigwinch = true;
+ }
+ 
+ static void curses_winch_init(void)
+ {
+-    struct sigaction old, winch = {
+-        .sa_handler  = curses_winch_handler,
++    static Notifier n = {
++        .notify = curses_winch_handler
+     };
+-    sigaction(SIGWINCH, &winch, &old);
++    sigwinch_add_notifier(&n);
+ }
+ #else
+ static void curses_winch_check(void) {}
+diff --git a/util/main-loop.c b/util/main-loop.c
+index ad8645c30a..136886e4ee 100644
+--- a/util/main-loop.c
++++ b/util/main-loop.c
+@@ -100,6 +100,7 @@ static int qemu_signal_init(Error **errp)
+     sigaddset(&set, SIGIO);
+     sigaddset(&set, SIGALRM);
+     sigaddset(&set, SIGBUS);
++    sigaddset(&set, SIGWINCH);
+     /* SIGINT cannot be handled via signalfd, so that ^C can be used
+      * to interrupt QEMU when it is being run under gdb.  SIGHUP and
+      * SIGTERM are also handled asynchronously, even though it is not
+@@ -124,6 +125,26 @@ static int qemu_signal_init(Error **errp)
+     return 0;
+ }
+ 
++static NotifierList sigwinch_notifiers =
++    NOTIFIER_LIST_INITIALIZER(sigwinch_notifiers);
++
++static void sigwinch_handler(int signum)
++{
++    notifier_list_notify(&sigwinch_notifiers, NULL);
++}
++
++void sigwinch_add_notifier(Notifier *n)
++{
++    if (notifier_list_empty(&sigwinch_notifiers)) {
++        struct sigaction action = {
++            .sa_handler = sigwinch_handler,
++        };
++        sigaction(SIGWINCH, &action, NULL);
++    }
++
++    notifier_list_add(&sigwinch_notifiers, n);
++}
++
+ #else /* _WIN32 */
+ 
+ static int qemu_signal_init(Error **errp)
+ 
+-- 
+2.52.0
+ 

--- a/lib/qemu-patches/0006-console-resize.patch
+++ b/lib/qemu-patches/0006-console-resize.patch
@@ -1,0 +1,91 @@
+From: Szymon Lukasz <noh4hss@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:49 +0100
+Subject: [PATCH] char-stdio: add support for the terminal size
+
+Update the terminal size upon SIGWINCH delivery.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+[Filip: use DECLARE_INSTANCE_CHECKER]
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+
+Adapted for QEMU 10.2.x: qemu_chr_open_stdio/qemu_chr_set_echo_stdio names.
+---
+ chardev/char-stdio.c | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/chardev/char-stdio.c b/chardev/char-stdio.c
+index 2568164a10..f55a7be24b 100644
+--- a/chardev/char-stdio.c
++++ b/chardev/char-stdio.c
+@@ -34,7 +34,9 @@
+ #include "chardev/char-win-stdio.h"
+ #else
+ #include <termios.h>
++#include <sys/ioctl.h>
+ #include "chardev/char-fd.h"
++#include "qemu/main-loop.h"
+ #endif
+
+ #ifndef _WIN32
+@@ -46,6 +48,14 @@ static bool stdio_in_use;
+ static bool stdio_allow_signal;
+ static bool stdio_echo_state;
+
++typedef struct {
++    FDChardev parent;
++    Notifier resize_notifier;
++} StdioChardev;
++
++DECLARE_INSTANCE_CHECKER(StdioChardev, STDIO_CHARDEV,
++                         TYPE_CHARDEV_STDIO)
++
+ static void term_exit(void)
+ {
+     if (stdio_in_use) {
+@@ -85,6 +95,20 @@ static void term_stdio_handler(int sig)
+     qemu_chr_set_echo_stdio(NULL, stdio_echo_state);
+ }
+
++static void qemu_chr_resize_stdio(Chardev *chr)
++{
++    struct winsize ws;
++    if (ioctl(1, TIOCGWINSZ, &ws) != -1) {
++        qemu_chr_resize(chr, ws.ws_col, ws.ws_row);
++    }
++}
++
++static void term_resize_notify(Notifier *n, void *data)
++{
++    StdioChardev *s = container_of(n, StdioChardev, resize_notifier);
++    qemu_chr_resize_stdio(CHARDEV(s));
++}
++
+ static void qemu_chr_open_stdio(Chardev *chr,
+                                 ChardevBackend *backend,
+                                 bool *be_opened,
+@@ -92,4 +116,5 @@ static void qemu_chr_open_stdio(Chardev *chr,
+ {
++    StdioChardev *s = STDIO_CHARDEV(chr);
+     ChardevStdio *opts = backend->u.stdio.data;
+     struct sigaction act;
+
+@@ -124,5 +149,9 @@ static void qemu_chr_open_stdio(Chardev *chr,
+     stdio_allow_signal = !opts->has_signal || opts->signal;
+     qemu_chr_set_echo_stdio(chr, false);
++
++    qemu_chr_resize_stdio(chr);
++    s->resize_notifier.notify = term_resize_notify;
++    sigwinch_add_notifier(&s->resize_notifier);
+ }
+ #endif
+
+@@ -162,6 +192,7 @@ static const TypeInfo char_stdio_type_info = {
+     .parent = TYPE_CHARDEV_WIN_STDIO,
+ #else
+     .parent = TYPE_CHARDEV_FD,
++    .instance_size = sizeof(StdioChardev),
+ #endif
+     .instance_finalize = char_stdio_finalize,
+     .class_init = char_stdio_class_init,
+--
+2.52.0

--- a/lib/qemu-patches/0007-console-resize.patch
+++ b/lib/qemu-patches/0007-console-resize.patch
@@ -1,0 +1,91 @@
+From: Szymon Lukasz <noh4hss@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:50 +0100
+Subject: [PATCH] qmp: add chardev-window-size-changed command
+
+The managment software can use this command to notify QEMU about the
+size of the terminal connected to a chardev, QEMU can then forward this
+information to the guest if the chardev is connected to a virtio console
+device.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+Suggested-by: Daniel P. Berrangé <berrange@redhat.com>
+[Filip: rename command, change documentation]
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+Acked-by: Markus Armbruster <armbru@redhat.com>
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+---
+ chardev/char.c | 14 ++++++++++++++
+ qapi/char.json | 31 +++++++++++++++++++++++++++++++
+ 2 files changed, 45 insertions(+)
+
+diff --git a/chardev/char.c b/chardev/char.c
+index f3c6a12c99..458059a9e0 100644
+--- a/chardev/char.c
++++ b/chardev/char.c
+@@ -1266,6 +1266,20 @@ bool qmp_add_client_char(int fd, bool has_skipauth, bool skipauth,
+     return true;
+ }
+ 
++void qmp_chardev_window_size_changed(const char *id, uint16_t cols,
++                                     uint16_t rows, Error **errp)
++{
++    Chardev *chr;
++
++    chr = qemu_chr_find(id);
++    if (chr == NULL) {
++        error_setg(errp, "Chardev '%s' not found", id);
++        return;
++    }
++
++    qemu_chr_resize(chr, cols, rows);
++}
++
+ /*
+  * Add a timeout callback for the chardev (in milliseconds), return
+  * the GSource object created. Please use this to add timeout hook for
+diff --git a/qapi/char.json b/qapi/char.json
+index 140614f82c..bc08f0161a 100644
+--- a/qapi/char.json
++++ b/qapi/char.json
+@@ -861,6 +861,37 @@
+ { 'command': 'chardev-send-break',
+   'data': { 'id': 'str' } }
+ 
++##
++# @chardev-window-size-changed:
++#
++# Notifies a chardev about the current size of the terminal connected
++# to this chardev.  The information will be forwarded to the guest if
++# the chardev is connected to a virtio console device.
++#
++# The initial size is 0x0, which should be interpreted as an unknown
++# size.
++#
++# Some backends detect the terminal size automatically, in which case
++# the size may unpredictably revert to the detected one at any time.
++#
++# @id: the chardev's ID, must exist
++#
++# @cols: the number of columns
++#
++# @rows: the number of rows
++#
++# Since: 11.0
++#
++# .. qmp-example::
++#
++#     -> { "execute": "chardev-window-size-changed", "arguments": { "id": "foo", "cols": 80, "rows": 24 } }
++#     <- { "return": {} }
++##
++{ 'command': 'chardev-window-size-changed',
++  'data': { 'id': 'str',
++            'cols': 'uint16',
++            'rows': 'uint16' } }
++
+ ##
+ # @VSERPORT_CHANGE:
+ #
+ 
+-- 
+2.52.0
+ 

--- a/lib/qemu-patches/0008-console-resize.patch
+++ b/lib/qemu-patches/0008-console-resize.patch
@@ -1,0 +1,178 @@
+From: Filip Hejsek <filip.hejsek@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:51 +0100
+Subject: [PATCH] virtio-serial-bus: add terminal resize messages
+
+Implement the part of the virtio spec that allows to notify the virtio
+driver about terminal resizes. The virtio spec contains two methods to
+achieve that:
+
+For legacy drivers, we have only one port and we put the terminal size
+in the config space and inject the config changed interrupt.
+
+For multiport devices, we use the control virtqueue to send a packet
+containing the terminal size. Note that old versions of the Linux kernel
+used an incorrect order for the fields (rows then cols instead of cols
+then rows), until it was fixed by commit 5326ab737a47278dbd16ed3ee7380b26c7056ddd.
+
+As a result, when using a Linux kernel older than 6.15, the number of rows
+and columns will be swapped.
+
+Based on a patch originally written by Szymon Lukasz <noh4hss@gmail.com>,
+but partially rewritten to fix various corner cases.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+---
+ hw/char/trace-events              |  1 +
+ hw/char/virtio-serial-bus.c       | 76 +++++++++++++++++++++++++++++++++++++--
+ hw/core/machine.c                 |  4 ++-
+ include/hw/virtio/virtio-serial.h |  5 +++
+ 4 files changed, 83 insertions(+), 3 deletions(-)
+
+diff --git a/hw/char/trace-events b/hw/char/trace-events
+index 9e74be2c14..2416d4d04e 100644
+--- a/hw/char/trace-events
++++ b/hw/char/trace-events
+@@ -11,6 +11,7 @@ serial_update_parameters(uint64_t baudrate, char parity, int data_bits, int stop
+ 
+ # virtio-serial-bus.c
+ virtio_serial_send_control_event(unsigned int port, uint16_t event, uint16_t value) "port %u, event %u, value %u"
++virtio_serial_send_console_resize(unsigned int port, uint16_t cols, uint16_t rows) "port %u, cols %u, rows %u"
+ virtio_serial_throttle_port(unsigned int port, bool throttle) "port %u, throttle %d"
+ virtio_serial_handle_control_message(uint16_t event, uint16_t value) "event %u, value %u"
+ virtio_serial_handle_control_message_port(unsigned int port) "port %u"
+diff --git a/hw/char/virtio-serial-bus.c b/hw/char/virtio-serial-bus.c
+index 5ec5f5313b..6348eef3a2 100644
+--- a/hw/char/virtio-serial-bus.c
++++ b/hw/char/virtio-serial-bus.c
+@@ -260,6 +260,68 @@ static size_t send_control_event(VirtIOSerial *vser, uint32_t port_id,
+     return send_control_msg(vser, &cpkt, sizeof(cpkt));
+ }
+ 
++/*
++ * This struct should be added to the Linux kernel uapi headers
++ * and later imported to standard-headers/linux/virtio_console.h
++ */
++struct virtio_console_resize {
++    __virtio16 cols;
++    __virtio16 rows;
++};
++
++static void send_console_resize(VirtIOSerialPort *port)
++{
++    VirtIOSerial *vser = port->vser;
++    VirtIODevice *vdev = VIRTIO_DEVICE(vser);
++
++    if (!virtio_has_feature(vser->host_features, VIRTIO_CONSOLE_F_SIZE)) {
++        return;
++    }
++
++    trace_virtio_serial_send_console_resize(port->id, port->cols, port->rows);
++
++    if (use_multiport(vser)) {
++        struct {
++            struct virtio_console_control control;
++            struct virtio_console_resize resize;
++        } buffer;
++
++        virtio_stl_p(vdev, &buffer.control.id, port->id);
++        virtio_stw_p(vdev, &buffer.control.event, VIRTIO_CONSOLE_RESIZE);
++        virtio_stw_p(vdev, &buffer.resize.cols, port->cols);
++        virtio_stw_p(vdev, &buffer.resize.rows, port->rows);
++
++        send_control_msg(vser, &buffer, sizeof(buffer));
++    }
++}
++
++void virtio_serial_resize_console(VirtIOSerialPort *port,
++                                  uint16_t cols, uint16_t rows)
++{
++    VirtIOSerial *vser = port->vser;
++    VirtIODevice *vdev = VIRTIO_DEVICE(vser);
++
++    if (port->cols == cols && port->rows == rows) {
++        return;
++    }
++
++    port->cols = cols;
++    port->rows = rows;
++
++    if (port->id == 0 && !use_multiport(vser) &&
++        virtio_vdev_has_feature(vdev, VIRTIO_CONSOLE_F_SIZE)) {
++        virtio_notify_config(vdev);
++    }
++
++    /*
++     * We will send these messages even before we told the guest that
++     * it is a console port (by sending VIRTIO_CONSOLE_CONSOLE_PORT
++     * message), but that should be fine as the guest will likely
++     * ignore them.
++     */
++    send_console_resize(port);
++}
++
+ /* Functions for use inside qemu to open and read from/write to ports */
+ int virtio_serial_open(VirtIOSerialPort *port)
+ {
+@@ -408,6 +470,7 @@ static void handle_control_message(VirtIOSerial *vser, void *buf, size_t len)
+          */
+         if (vsc->is_console) {
+             send_control_event(vser, port->id, VIRTIO_CONSOLE_CONSOLE_PORT, 1);
++            send_console_resize(port);
+         }
+ 
+         if (port->name) {
+@@ -568,11 +630,18 @@ static uint64_t get_features(VirtIODevice *vdev, uint64_t features,
+ static void get_config(VirtIODevice *vdev, uint8_t *config_data)
+ {
+     VirtIOSerial *vser = VIRTIO_SERIAL(vdev);
++    VirtIOSerialPort *port;
+     struct virtio_console_config *config =
+         (struct virtio_console_config *)config_data;
+ 
+-    config->cols = 0;
+-    config->rows = 0;
++    port = find_port_by_id(vser, 0);
++    if (port) {
++        config->cols = virtio_tswap16(vdev, port->cols);
++        config->rows = virtio_tswap16(vdev, port->rows);
++    } else {
++        config->cols = 0;
++        config->rows = 0;
++    }
+     config->max_nr_ports = virtio_tswap32(vdev,
+                                           vser->serial.max_virtserial_ports);
+ }
+@@ -1158,6 +1228,8 @@ static const Property virtio_serial_properties[] = {
+                                                  31),
+     DEFINE_PROP_BIT64("emergency-write", VirtIOSerial, host_features,
+                       VIRTIO_CONSOLE_F_EMERG_WRITE, true),
++    DEFINE_PROP_BIT64("console-size", VirtIOSerial, host_features,
++                      VIRTIO_CONSOLE_F_SIZE, true),
+ };
+
+ static void virtio_serial_class_init(ObjectClass *klass, const void *data)
+diff --git a/include/hw/virtio/virtio-serial.h b/include/hw/virtio/virtio-serial.h
+index 60641860bf..bda6d5312a 100644
+--- a/include/hw/virtio/virtio-serial.h
++++ b/include/hw/virtio/virtio-serial.h
+@@ -145,6 +145,9 @@ struct VirtIOSerialPort {
+     bool host_connected;
+     /* Do apps not want to receive data? */
+     bool throttled;
++
++    /* Terminal size reported to the guest.  Only used for consoles. */
++    uint16_t cols, rows;
+ };
+
+ /* The virtio-serial bus on top of which the ports will ride as devices */
+@@ -222,5 +225,7 @@ size_t virtio_serial_guest_ready(VirtIOSerialPort *port);
+  */
+ void virtio_serial_throttle_port(VirtIOSerialPort *port, bool throttle);
+ 
++void virtio_serial_resize_console(VirtIOSerialPort *port,
++                                  uint16_t cols, uint16_t rows);
+ 
+ #endif
+ 
+-- 

--- a/lib/qemu-patches/0009-console-resize.patch
+++ b/lib/qemu-patches/0009-console-resize.patch
@@ -1,0 +1,89 @@
+From: Szymon Lukasz <noh4hss@gmail.com>
+Date: Mon, 19 Jan 2026 04:27:52 +0100
+Subject: [PATCH] virtio-console: notify the guest about terminal resizes
+
+If a virtio serial port is a console port, forward terminal resize
+messages from the chardev backend to the guest.
+
+Signed-off-by: Szymon Lukasz <noh4hss@gmail.com>
+[Filip: rename things, remove logic that is now handled in virtio-serial-bus.c]
+Signed-off-by: Filip Hejsek <filip.hejsek@gmail.com>
+---
+ hw/char/virtio-console.c | 34 +++++++++++++++++++++++++++++++---
+ 1 file changed, 31 insertions(+), 3 deletions(-)
+
+diff --git a/hw/char/virtio-console.c b/hw/char/virtio-console.c
+index dcfe5830f9..de7979c2d3 100644
+--- a/hw/char/virtio-console.c
++++ b/hw/char/virtio-console.c
+@@ -107,6 +107,15 @@ static ssize_t flush_buf(VirtIOSerialPort *port,
+     return ret;
+ }
+ 
++static void virtconsole_update_size(VirtIOSerialPort *port)
++{
++    uint16_t cols, rows;
++    VirtConsole *vcon = VIRTIO_CONSOLE(port);
++
++    qemu_chr_fe_get_winsize(&vcon->chr, &cols, &rows);
++    virtio_serial_resize_console(port, cols, rows);
++}
++
+ /* Callback function that's called when the guest opens/closes the port */
+ static void set_guest_connected(VirtIOSerialPort *port, int guest_connected)
+ {
+@@ -174,6 +183,23 @@ static void chr_event(void *opaque, QEMUChrEvent event)
+     }
+ }
+ 
++static void chr_event_console(void *opaque, QEMUChrEvent event)
++{
++    VirtConsole *vcon = opaque;
++    VirtIOSerialPort *port = VIRTIO_SERIAL_PORT(vcon);
++
++    trace_virtio_console_chr_event(port->id, event);
++    switch (event) {
++    case CHR_EVENT_OPENED:
++    case CHR_EVENT_MUX_IN:
++    case CHR_EVENT_RESIZE:
++        virtconsole_update_size(port);
++        break;
++    default:
++        break;
++    }
++}
++
+ static int chr_be_change(void *opaque)
+ {
+     VirtConsole *vcon = opaque;
+@@ -182,7 +208,9 @@ static int chr_be_change(void *opaque)
+ 
+     if (k->is_console) {
+         qemu_chr_fe_set_handlers(&vcon->chr, chr_can_read, chr_read,
+-                                 NULL, chr_be_change, vcon, NULL, true);
++                                 chr_event_console, chr_be_change,
++                                 vcon, NULL, true);
++        virtconsole_update_size(port);
+     } else {
+         qemu_chr_fe_set_handlers(&vcon->chr, chr_can_read, chr_read,
+                                  chr_event, chr_be_change, vcon, NULL, false);
+@@ -210,7 +238,7 @@ static void virtconsole_enable_backend(VirtIOSerialPort *port, bool enable)
+         VirtIOSerialPortClass *k = VIRTIO_SERIAL_PORT_GET_CLASS(port);
+ 
+         qemu_chr_fe_set_handlers(&vcon->chr, chr_can_read, chr_read,
+-                                 k->is_console ? NULL : chr_event,
++                                 k->is_console ? chr_event_console : chr_event,
+                                  chr_be_change, vcon, NULL, false);
+     } else {
+         qemu_chr_fe_set_handlers(&vcon->chr, NULL, NULL, NULL,
+@@ -242,7 +270,7 @@ static void virtconsole_realize(DeviceState *dev, Error **errp)
+          */
+         if (k->is_console) {
+             qemu_chr_fe_set_handlers(&vcon->chr, chr_can_read, chr_read,
+-                                     NULL, chr_be_change,
++                                     chr_event_console, chr_be_change,
+                                      vcon, NULL, true);
+             virtio_serial_open(port);
+         } else {
+ 
+-- 

--- a/lib/qemuOverlay.nix
+++ b/lib/qemuOverlay.nix
@@ -1,0 +1,45 @@
+# Overlay that patches the nixpkgs QEMU with virtio-console terminal resize
+# support (SIGWINCH propagation to guest). The resize feature is not upstream
+# yet — it comes from the patch series below. Once merged in a stable QEMU
+# release, the patches and this overlay can be dropped.
+final: prev: {
+  qemu = prev.qemu.overrideAttrs (old: {
+    # virtio-console resize patch series (v6) by Filip Hejsek & Szymon Lukasz
+    # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-0-33a7b0330a7a@gmail.com/
+    # Patches adapted to apply against QEMU 10.2.x where noted.
+    patches = (old.patches or [ ]) ++ [
+      # 01/12: chardev: add cols, rows fields
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-1-33a7b0330a7a@gmail.com/
+      ./qemu-patches/0001-console-resize.patch
+      # 02/12: chardev: add CHR_EVENT_RESIZE
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-2-33a7b0330a7a@gmail.com/
+      ./qemu-patches/0002-console-resize.patch
+      # 03/12: chardev: add qemu_chr_resize()
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-3-33a7b0330a7a@gmail.com/
+      ./qemu-patches/0003-console-resize.patch
+      # 04/12: char-mux: add support for the terminal size
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-4-33a7b0330a7a@gmail.com/
+      # Adapted: updated context for qemu_chr_open_mux signature (void + be_opened in 10.2.x)
+      ./qemu-patches/0004-console-resize.patch
+      # 05/12: main-loop: change the handling of SIGWINCH
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-5-33a7b0330a7a@gmail.com/
+      ./qemu-patches/0005-console-resize.patch
+      # 06/12: char-stdio: add support for the terminal size
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-6-33a7b0330a7a@gmail.com/
+      # Adapted: updated context for qemu_chr_open_stdio/qemu_chr_set_echo_stdio names (10.2.x)
+      ./qemu-patches/0006-console-resize.patch
+      # 07/12: qmp: add chardev-window-size-changed command
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-7-33a7b0330a7a@gmail.com/
+      ./qemu-patches/0007-console-resize.patch
+      # 08/12: virtio-serial-bus: add terminal resize messages
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-8-33a7b0330a7a@gmail.com/
+      # Adapted: updated virtio_serial_properties context (emergency-write exists in 10.2.x),
+      # removed hw_compat_10_2 hunk (doesn't exist in 10.2.x)
+      ./qemu-patches/0008-console-resize.patch
+      # 09/12: virtio-console: notify the guest about terminal resizes
+      # https://lore.kernel.org/qemu-devel/20260119-console-resize-v6-9-33a7b0330a7a@gmail.com/
+      ./qemu-patches/0009-console-resize.patch
+      # Patches 10-12 (curses, GTK, tests) are not needed for headless virtio-console use.
+    ];
+  });
+}


### PR DESCRIPTION
Switched the TTY from serial (ttyS0) to virtio-console (hvc0) with SIGWINCH propagation using patches by Filip Hejsek & Szymon Lukasz that haven't been upstreamed yet.

Closes #8 