### PR TITLE
feat: add immutable and tmpdir args

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ llm-jail-{claude,codex,copilot} [options] [-- tool-args...]
 | `--dangerous` | Enable the tool's dangerous / unattended mode | off |
 | `--config-dir PATH` | Tool config directory | `~/.claude` or `~/.codex` |
 | `--immutable` | Mount workspace as read-only | off |
+| `--tmpdir PATH` | Directory to use for runtime data | `${TMPDIR:-/tmp}` |
 | `--mount PATH` | Extra read-write mount (repeatable) | — |
 | `--ro-mount PATH` | Extra read-only mount (repeatable) | — |
 | `--dev-env` | Capture `nix develop` environment from workspace | off |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ llm-jail-{claude,codex,copilot} [options] [-- tool-args...]
 |------|-------------|---------|
 | `--dangerous` | Enable the tool's dangerous / unattended mode | off |
 | `--config-dir PATH` | Tool config directory | `~/.claude` or `~/.codex` |
+| `--immutable` | Mount workspace as read-only | off |
 | `--mount PATH` | Extra read-write mount (repeatable) | — |
 | `--ro-mount PATH` | Extra read-only mount (repeatable) | — |
 | `--dev-env` | Capture `nix develop` environment from workspace | off |

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -28,6 +28,7 @@ pkgs.writeShellApplication {
     VCPU="${toString toolDefaults.vcpu}"
     DANGEROUS=0
     DEV_ENV=0
+    IMMUTABLE=0
     STORE_DISK=0
     CONFIG_DIR="''${LLMJAIL_CONFIG_DIR:-$HOME/${toolDefaults.configDirName}}"
     NET_FILTER=1
@@ -43,6 +44,7 @@ pkgs.writeShellApplication {
     Options:
       --dangerous           Enable the tool's dangerous / unattended mode
       --config-dir PATH     Tool config directory (default: ~/${toolDefaults.configDirName})
+      --immutable           Mount workspace as read-only instead of read-write
       --mount PATH          Extra read-write mount at same path in guest (repeatable)
       --ro-mount PATH       Extra read-only mount at same path in guest (repeatable)
       --dev-env             Capture nix develop environment from workspace flake
@@ -79,6 +81,7 @@ pkgs.writeShellApplication {
         --config-dir)  CONFIG_DIR="$2"; shift 2 ;;
         --mount)       EXTRA_MOUNTS+=("$2:rw"); shift 2 ;;
         --ro-mount)    EXTRA_MOUNTS+=("$2:ro"); shift 2 ;;
+        --immutable)    IMMUTABLE=1; shift ;;
         --allow-domain)  EXTRA_DOMAINS+=("$2"); shift 2 ;;
         --no-net-filter) NET_FILTER=0; shift ;;
         --store-disk)  STORE_DISK="$2"; shift 2 ;;
@@ -264,7 +267,12 @@ pkgs.writeShellApplication {
     }
 
     # Default mounts
-    add_mount "$(pwd)" "/workspace" "rw"
+    if [[ "$IMMUTABLE" -eq 1 ]]; then
+      add_mount "$(pwd)" "/workspace" "ro-nocache"
+    else
+      add_mount "$(pwd)" "/workspace" "rw"
+    fi
+
 
     # Mount config dir read-only with no cache (overlay lower layer)
     # cache=none ensures host-side credential refreshes are visible instantly

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -29,6 +29,7 @@ pkgs.writeShellApplication {
     DANGEROUS=0
     DEV_ENV=0
     IMMUTABLE=0
+    LLMJAIL_TMPDIR=''${TMPDIR:-/tmp}
     STORE_DISK=0
     CONFIG_DIR="''${LLMJAIL_CONFIG_DIR:-$HOME/${toolDefaults.configDirName}}"
     NET_FILTER=1
@@ -45,6 +46,7 @@ pkgs.writeShellApplication {
       --dangerous           Enable the tool's dangerous / unattended mode
       --config-dir PATH     Tool config directory (default: ~/${toolDefaults.configDirName})
       --immutable           Mount workspace as read-only instead of read-write
+      --tmpdir PATH         Directory to use for runtime data (default: ''${TMPDIR:-/tmp})
       --mount PATH          Extra read-write mount at same path in guest (repeatable)
       --ro-mount PATH       Extra read-only mount at same path in guest (repeatable)
       --dev-env             Capture nix develop environment from workspace flake
@@ -81,6 +83,7 @@ pkgs.writeShellApplication {
         --config-dir)  CONFIG_DIR="$2"; shift 2 ;;
         --mount)       EXTRA_MOUNTS+=("$2:rw"); shift 2 ;;
         --ro-mount)    EXTRA_MOUNTS+=("$2:ro"); shift 2 ;;
+        --tmpdir)      LLMJAIL_TMPDIR="$2"; shift 2 ;;
         --immutable)    IMMUTABLE=1; shift ;;
         --allow-domain)  EXTRA_DOMAINS+=("$2"); shift 2 ;;
         --no-net-filter) NET_FILTER=0; shift ;;
@@ -93,8 +96,12 @@ pkgs.writeShellApplication {
       esac
     done
 
-    # ── Temp dir for env file ─────────────────────────────────────────
-    RUNDIR="$(mktemp -d)"
+    if [ ! -d "$LLMJAIL_TMPDIR" ]; then
+      echo "ERROR: tmpdir '$LLMJAIL_TMPDIR' does not exist" >&2
+      exit 1
+    fi
+    RUNDIR=$(mktemp -d --tmpdir="$LLMJAIL_TMPDIR")
+
     cleanup_rundir() {
       [ -d "$RUNDIR" ] && rm -rf "$RUNDIR"
     }


### PR DESCRIPTION
`--immutable` allows mounting PWD into the VM in read-only
`--tmpdir` allows specifying the directory to put runtime data in. ie. putting store disk in /tmp when it's a tmpfs is not good
