### PR TITLE
All in one improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Supported tools:
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `llm-jail-claude` | `--dangerously-skip-permissions` |
 | [Codex CLI](https://github.com/openai/codex) | `llm-jail-codex` | `--dangerously-bypass-approvals-and-sandbox` |
 | [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | `llm-jail-copilot` | `--yolo` |
+| Interactive shell (debugging) | `llm-jail-shell` | — |
 
 ## Requirements
 
@@ -31,6 +32,9 @@ nix run github:braiins/llm-jail#codex
 
 # Run GitHub Copilot CLI
 nix run github:braiins/llm-jail#copilot
+
+# Drop into a shell inside the sandbox (for debugging the jail itself)
+nix run github:braiins/llm-jail#shell
 ```
 
 Pass tool arguments after `--`:
@@ -42,7 +46,7 @@ nix run github:braiins/llm-jail#claude -- -- -p "Refactor the auth module" --max
 ## Usage
 
 ```
-llm-jail-{claude,codex,copilot} [options] [-- tool-args...]
+llm-jail-{claude,codex,copilot,shell} [options] [-- tool-args...]
 ```
 
 ### Options
@@ -108,6 +112,16 @@ Run `nix build` inside the VM with extra storage (root tmpfs is only 2G):
 ```bash
 nix run .#claude -- --store-disk 20 -- -p "nix build and run the tests"
 ```
+
+Drop into your own shell inside the sandbox to inspect mounts or reproduce tool behavior manually:
+
+```bash
+nix run .#shell                              # offline, your shell rc files copied in
+nix run .#shell -- --allow-domain github.com # opt in to specific domains
+nix run .#shell -- --no-net-filter           # full network for debugging
+```
+
+The shell tool honors `$SHELL` (resolved through symlinks so the `/nix/store` path is used) and falls back to zsh or bash if the host shell isn't reachable inside the guest (e.g. on non-NixOS hosts). The following dotfiles are copied from `$HOME` if they exist: `.bashrc`, `.bash_profile`, `.bash_logout`, `.profile`, `.zshrc`, `.zshenv`, `.zprofile`, `.zlogin`, `.inputrc`. Any rc-file references to host-only paths (plugin managers in `~/.zsh/plugins`, etc.) will produce startup errors; bring those in with `--ro-mount` as needed.
 
 ## What's isolated
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Default allowed domains per tool:
 | Copilot | `github.com`, `api.github.com`, `api.individual.githubcopilot.com`, `copilot-proxy.githubusercontent.com`, `githubcopilot.com`, `collector.github.com`, … |
 
 > [!NOTE]
-> DNS-based filtering prevents the agent from resolving non-whitelisted domains, but does not prevent connections to hardcoded IP addresses on ports 80/443. This is adequate for preventing accidental or prompt-injected exfiltration by LLM agents, which use domain names rather than raw IPs.
+> Outbound HTTP/HTTPS is restricted to IPs that the guest's dnsmasq resolved through a whitelisted domain — every successful lookup populates an nftables set (`allowed_ips`), and the firewall only accepts packets whose destination is in that set. Connections to hardcoded IPs that bypass DNS hit the default drop. IPv6 outbound traffic is dropped outright (no IPv6 rules). This is robust against accidental or prompt-injected exfiltration as long as the whitelisted domains themselves aren't bidirectional data channels — see the dangerous-mode warning below.
 
 ## Dangerous mode
 

--- a/guests/claude.nix
+++ b/guests/claude.nix
@@ -1,9 +1,20 @@
-{ claude-code, ... }:
+{ pkgs, claude-code, ... }:
 
 {
   imports = [ ./common.nix ];
 
-  llmjail.toolBinary = "${claude-code}/bin/claude";
+  # Pre-trust /workspace so claude doesn't ask "Is this a project you trust?"
+  # on every run. The path is constant inside the VM, and the .claude.json
+  # we patch here is the tmpfs copy — host file is untouched.
+  llmjail.toolBinary = pkgs.writeShellScript "claude-launcher" ''
+    CLAUDE_JSON="$HOME/.claude.json"
+    if [ ! -f "$CLAUDE_JSON" ]; then
+      echo '{}' > "$CLAUDE_JSON"
+    fi
+    ${pkgs.jq}/bin/jq '.projects["/workspace"] = ((.projects["/workspace"] // {}) + {hasTrustDialogAccepted: true})' \
+      "$CLAUDE_JSON" > "$CLAUDE_JSON.tmp" && mv "$CLAUDE_JSON.tmp" "$CLAUDE_JSON"
+    exec ${claude-code}/bin/claude "$@"
+  '';
   llmjail.dangerousFlag = "--dangerously-skip-permissions";
 
   environment.systemPackages = [

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -16,6 +16,11 @@
   config = {
     # ── Boot ──────────────────────────────────────────────────────────────
     boot.loader.grub.enable = false;
+    # postMountCommands below is classic stage 1 only — assert against the
+    # systemd-stage-1 default that newer nixpkgs (26.05+) flips on. Until we
+    # port the /nix/store overlay setup to a systemd-initrd service, force
+    # classic.
+    boot.initrd.systemd.enable = lib.mkForce false;
     boot.kernelParams = [ "console=ttyS1" ];
     boot.initrd.availableKernelModules = [
       "9p"

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -265,10 +265,11 @@
           # Populated by dnsmasq --nftset on each successful DNS resolution.
           # HTTP/HTTPS is only allowed to IPs that appear here, blocking
           # direct hardcoded-IP connections that bypass DNS filtering.
+          # Plain set (no `flags interval`) so dnsmasq can add individual
+          # /32 entries — interval sets reject single addresses in some
+          # nft/dnsmasq combos.
           set allowed_ips {
             type ipv4_addr
-            flags interval
-            auto-merge
           }
 
           chain output {
@@ -318,9 +319,17 @@
         } > "$DNSMASQ_CONF"
 
         # ── Start dnsmasq ───────────────────────────────────────────
+        # --user=root keeps CAP_NET_ADMIN for the lifetime of the daemon;
+        # dnsmasq otherwise drops to "nobody" and nftset updates fail
+        # silently. We're inside a jail VM, root for dnsmasq is fine.
+        # --log-queries surfaces the nftset add events in journalctl so
+        # future filter regressions are debuggable from the guest.
         ${pkgs.dnsmasq}/bin/dnsmasq \
           --conf-file="$DNSMASQ_CONF" \
-          --pid-file=/run/dnsmasq-llmjail.pid
+          --pid-file=/run/dnsmasq-llmjail.pid \
+          --user=root \
+          --log-queries=extra \
+          --log-facility=-
 
         # ── Point resolv.conf at local dnsmasq ──────────────────────
         echo "nameserver 127.0.0.1" > /etc/resolv.conf

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -252,36 +252,20 @@
           exit 0
         fi
 
-        # ── Generate dnsmasq config ─────────────────────────────────
-        DNSMASQ_CONF="/etc/dnsmasq-llmjail.conf"
-        {
-          echo "no-resolv"
-          echo "no-hosts"
-          echo "listen-address=127.0.0.1"
-          echo "bind-interfaces"
-
-          # Forward allowed domains to QEMU's DNS
-          if [ -f /llmjail-env/allowed-domains ]; then
-            while IFS= read -r domain || [ -n "$domain" ]; do
-              [ -z "$domain" ] && continue
-              echo "server=/$domain/10.0.2.3"
-            done < /llmjail-env/allowed-domains
-          fi
-
-          # No default upstream — unmatched queries get REFUSED
-        } > "$DNSMASQ_CONF"
-
-        # ── Start dnsmasq ───────────────────────────────────────────
-        ${pkgs.dnsmasq}/bin/dnsmasq \
-          --conf-file="$DNSMASQ_CONF" \
-          --pid-file=/run/dnsmasq-llmjail.pid
-
-        # ── Point resolv.conf at local dnsmasq ──────────────────────
-        echo "nameserver 127.0.0.1" > /etc/resolv.conf
-
         # ── Apply nftables firewall rules ───────────────────────────
+        # Must run before dnsmasq so allowed_ips set exists when
+        # dnsmasq populates it on first DNS resolution.
         ${pkgs.nftables}/bin/nft -f - <<'NFTEOF'
         table inet llmjail_filter {
+          # Populated by dnsmasq --nftset on each successful DNS resolution.
+          # HTTP/HTTPS is only allowed to IPs that appear here, blocking
+          # direct hardcoded-IP connections that bypass DNS filtering.
+          set allowed_ips {
+            type ipv4_addr
+            flags interval
+            auto-merge
+          }
+
           chain output {
             type filter hook output priority 0; policy drop;
 
@@ -298,14 +282,43 @@
             ip daddr 10.0.2.3 udp dport 53 accept
             ip daddr 10.0.2.3 tcp dport 53 accept
 
-            # Allow outbound HTTP/HTTPS
-            tcp dport { 80, 443 } accept
+            # Allow outbound HTTP/HTTPS only to DNS-resolved allowed IPs
+            ip daddr @allowed_ips tcp dport { 80, 443 } accept
 
             # Drop everything else
             log prefix "llmjail-drop: " drop
           }
         }
         NFTEOF
+
+        # ── Generate dnsmasq config ─────────────────────────────────
+        DNSMASQ_CONF="/etc/dnsmasq-llmjail.conf"
+        {
+          echo "no-resolv"
+          echo "no-hosts"
+          echo "listen-address=127.0.0.1"
+          echo "bind-interfaces"
+
+          # Forward allowed domains to QEMU's DNS; populate nftables set
+          # on each successful resolution so the IP becomes reachable.
+          if [ -f /llmjail-env/allowed-domains ]; then
+            while IFS= read -r domain || [ -n "$domain" ]; do
+              [ -z "$domain" ] && continue
+              echo "server=/$domain/10.0.2.3"
+              echo "nftset=/$domain/4#inet#llmjail_filter#allowed_ips"
+            done < /llmjail-env/allowed-domains
+          fi
+
+          # No default upstream — unmatched queries get REFUSED
+        } > "$DNSMASQ_CONF"
+
+        # ── Start dnsmasq ───────────────────────────────────────────
+        ${pkgs.dnsmasq}/bin/dnsmasq \
+          --conf-file="$DNSMASQ_CONF" \
+          --pid-file=/run/dnsmasq-llmjail.pid
+
+        # ── Point resolv.conf at local dnsmasq ──────────────────────
+        echo "nameserver 127.0.0.1" > /etc/resolv.conf
 
         echo "Network filtering enabled with $(${pkgs.coreutils}/bin/wc -l < /llmjail-env/allowed-domains) allowed domain(s)."
       '';

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -16,11 +16,9 @@
   config = {
     # ── Boot ──────────────────────────────────────────────────────────────
     boot.loader.grub.enable = false;
-    # postMountCommands below is classic stage 1 only — assert against the
-    # systemd-stage-1 default that newer nixpkgs (26.05+) flips on. Until we
-    # port the /nix/store overlay setup to a systemd-initrd service, force
-    # classic.
-    boot.initrd.systemd.enable = lib.mkForce false;
+    # Switch to systemd-initrd (default in 26.11). Required because we use
+    # boot.initrd.systemd.services below to set up the /nix/store overlay.
+    boot.initrd.systemd.enable = true;
     boot.kernelParams = [ "console=ttyS1" ];
     boot.initrd.availableKernelModules = [
       "9p"
@@ -29,44 +27,72 @@
       "virtio_blk"
       "virtio_net"
       "virtio_rng"
-      "overlay"
     ];
+    # Force-load overlay in initrd: availableKernelModules only allows
+    # autoload, but the systemd-initrd path doesn't always trigger it for
+    # `mount -t overlay`, so make it explicit.
+    boot.initrd.kernelModules = [ "overlay" ];
     boot.kernelModules = [ "nf_tables" ];
 
     boot.initrd.supportedFilesystems = [ "ext4" ];
 
-    # Mount nix store overlay and nix/var in postMountCommands so we control
-    # ordering: the backing device (ext4 or tmpfs) MUST be mounted before the
-    # overlay, and postMountCommands runs after all neededForBoot fileSystems
-    # (including /.nix-lower/store) but before switch_root.
-    # The 9p mount is used directly as the overlay lower layer — overlayfs
-    # does not reliably cross submount boundaries, so the lower must be the
-    # mounted filesystem itself, not a parent directory containing it.
-    # /nix/var is bind-mounted from the backing so build artifacts
-    # (/nix/var/nix/builds/) land on the backing volume, not the root tmpfs.
-    boot.initrd.postMountCommands = ''
-      STORE_DISK=0
-      for arg in $(cat /proc/cmdline); do
-        case "$arg" in
-          llmjail.store_disk=1) STORE_DISK=1 ;;
-        esac
-      done
+    # Set up the /nix/store overlay and /nix/var bind in initrd. Runs after
+    # the 9p store mount (RequiresMountsFor) and ordered before
+    # initrd-fs.target so stage 2 sees the overlay. The backing device
+    # (ext4 disk or tmpfs) is chosen at runtime from llmjail.store_disk=1
+    # on the kernel cmdline. The 9p mount is used directly as the overlay
+    # lower layer — overlayfs does not reliably cross submount boundaries,
+    # so the lower must be the mounted filesystem itself. /nix/var is
+    # bind-mounted from the backing so build artifacts land there instead
+    # of the root tmpfs.
+    boot.initrd.systemd.services.llmjail-store-overlay = {
+      description = "Set up /nix/store overlay and /nix/var bind";
+      # Pulled in by initrd-fs.target AND by initrd-find-nixos-closure.service
+      # (the latter races us in 26.05+ and inspects /sysroot/nix/store before
+      # the overlay exists — so we must complete before it starts).
+      wantedBy = [ "initrd-fs.target" "initrd-find-nixos-closure.service" ];
+      before = [ "initrd-fs.target" "initrd-find-nixos-closure.service" ];
+      unitConfig = {
+        DefaultDependencies = false;
+        RequiresMountsFor = "/sysroot/.nix-lower/store";
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        # Mirror stdout/stderr to the kernel.log file (ttyS1) so failures
+        # are visible before we have journalctl. Drop after stabilizing.
+        StandardOutput = "journal+console";
+        StandardError = "journal+console";
+      };
+      script = ''
+        set -eu
 
-      mkdir -p $targetRoot/.nix-backing
-      if [ "$STORE_DISK" = "1" ]; then
-        mount /dev/vda $targetRoot/.nix-backing
-      else
-        mount -t tmpfs tmpfs $targetRoot/.nix-backing
-      fi
-      mkdir -p $targetRoot/.nix-backing/store-upper $targetRoot/.nix-backing/store-work $targetRoot/.nix-backing/var
+        STORE_DISK=0
+        for arg in $(cat /proc/cmdline); do
+          case "$arg" in
+            llmjail.store_disk=1) STORE_DISK=1 ;;
+          esac
+        done
 
-      mkdir -p $targetRoot/nix/store
-      mount -t overlay overlay $targetRoot/nix/store \
-        -o "lowerdir=$targetRoot/.nix-lower/store,upperdir=$targetRoot/.nix-backing/store-upper,workdir=$targetRoot/.nix-backing/store-work"
+        mkdir -p /sysroot/.nix-backing
+        if [ "$STORE_DISK" = "1" ]; then
+          mount /dev/vda /sysroot/.nix-backing
+        else
+          mount -t tmpfs tmpfs /sysroot/.nix-backing
+        fi
+        mkdir -p \
+          /sysroot/.nix-backing/store-upper \
+          /sysroot/.nix-backing/store-work \
+          /sysroot/.nix-backing/var
 
-      mkdir -p $targetRoot/nix/var
-      mount --bind $targetRoot/.nix-backing/var $targetRoot/nix/var
-    '';
+        mkdir -p /sysroot/nix/store
+        mount -t overlay overlay /sysroot/nix/store \
+          -o "lowerdir=/sysroot/.nix-lower/store,upperdir=/sysroot/.nix-backing/store-upper,workdir=/sysroot/.nix-backing/store-work"
+
+        mkdir -p /sysroot/nix/var
+        mount --bind /sysroot/.nix-backing/var /sysroot/nix/var
+      '';
+    };
 
     # ── Filesystems ───────────────────────────────────────────────────────
     fileSystems."/" = {
@@ -84,8 +110,9 @@
       neededForBoot = true;
     };
 
-    # /nix/store overlay and /nix/var bind-mount are done in postMountCommands
-    # (above) to ensure the backing device is ready first.
+    # /nix/store overlay and /nix/var bind-mount are done by the
+    # llmjail-store-overlay initrd service (above) which orders itself
+    # after the 9p lower layer is mounted.
 
     fileSystems."/llmjail-env" = {
       device = "envfs";

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -99,6 +99,13 @@
     networking.nameservers = [ "10.0.2.3" ];
     networking.firewall.enable = false;
 
+    # nixos-26.05 + systemd-networkd auto-enables resolved, which inserts
+    # "resolve" before "dns" in nsswitch and steals all hostname lookups
+    # to its own stub on 127.0.0.53/54. That bypasses our dnsmasq on
+    # 127.0.0.1, so nftset additions never happen. Force it off so glibc
+    # falls back to the "dns" NSS module and reads /etc/resolv.conf.
+    services.resolved.enable = false;
+
     # Gives interface name "eth0"
     networking.usePredictableInterfaceNames = false;
     systemd.network = {

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -4,8 +4,8 @@
   # ── Tool options (set by each guest module) ─────────────────────────────
   options.llmjail = {
     toolBinary = lib.mkOption {
-      type = lib.types.str;
-      description = "Path to the tool binary to exec in the guest";
+      type = lib.types.either lib.types.str lib.types.package;
+      description = "Path to the tool binary to exec in the guest (string or derivation)";
     };
     dangerousFlag = lib.mkOption {
       type = lib.types.str;

--- a/guests/shell.nix
+++ b/guests/shell.nix
@@ -1,0 +1,35 @@
+{ pkgs, ... }:
+
+{
+  imports = [ ./common.nix ];
+
+  llmjail.toolBinary = pkgs.writeShellScript "shell-launcher" ''
+    # Create an empty $HOME/.zshrc in the jail, so that zsh doesn't complain about it
+    ensure_zshrc() {
+      [ -e "$HOME/.zshrc" ] || : > "$HOME/.zshrc"
+    }
+
+    # Honor host's $SHELL (resolved through symlinks by the runner so the
+    # value points at /nix/store, which the guest reaches via 9p). Fall back
+    # to whatever shell is reachable via PATH (covers /host-user-sw and
+    # /host-sw on NixOS hosts), then to the guest's bash on non-NixOS hosts.
+    if [ -n "''${SHELL:-}" ] && [ -x "$SHELL" ]; then
+      case "''${SHELL##*/}" in zsh) ensure_zshrc ;; esac
+      exec "$SHELL" -l
+    fi
+    for cand in zsh bash; do
+      if command -v "$cand" >/dev/null 2>&1; then
+        [ "$cand" = zsh ] && ensure_zshrc
+        exec "$cand" -l
+      fi
+    done
+    exec ${pkgs.bashInteractive}/bin/bash -l
+  '';
+  # --dangerous is meaningless for an interactive shell.
+  llmjail.dangerousFlag = "";
+
+  environment.systemPackages = with pkgs; [
+    bashInteractive
+    zsh
+  ];
+}

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -100,6 +100,26 @@ pkgs.writeShellApplication {
       echo "ERROR: tmpdir '$LLMJAIL_TMPDIR' does not exist" >&2
       exit 1
     fi
+
+    # Paths used in virtfs option strings (comma-separated) and kernel cmdline
+    # (space-separated) cannot contain commas, spaces, or colons (mount spec delimiter).
+    validate_path() {
+      local path="$1" label="''${2:-path}"
+      if [[ "$path" == *,* ]]; then
+        echo "ERROR: $label must not contain commas: $path" >&2
+        exit 1
+      fi
+      if [[ "$path" == *\ * ]]; then
+        echo "ERROR: $label must not contain spaces: $path" >&2
+        exit 1
+      fi
+      if [[ "$path" == *:* ]]; then
+        echo "ERROR: $label must not contain colons: $path" >&2
+        exit 1
+      fi
+    }
+
+    validate_path "$LLMJAIL_TMPDIR" "tmpdir"
     RUNDIR=$(mktemp -d --tmpdir="$LLMJAIL_TMPDIR")
 
     cleanup_rundir() {
@@ -274,13 +294,14 @@ pkgs.writeShellApplication {
     }
 
     # Default mounts
+    validate_path "$(pwd)" "workspace path"
     if [[ "$IMMUTABLE" -eq 1 ]]; then
       add_mount "$(pwd)" "/workspace" "ro-nocache"
     else
       add_mount "$(pwd)" "/workspace" "rw"
     fi
 
-
+    validate_path "$CONFIG_DIR" "config directory"
     # Mount config dir read-only with no cache (overlay lower layer)
     # cache=none ensures host-side credential refreshes are visible instantly
     add_mount "$CONFIG_DIR" "/home/user/${toolDefaults.configDirName}-ro" "ro-nocache"
@@ -350,6 +371,7 @@ pkgs.writeShellApplication {
         echo "ERROR: mount path does not exist or is not a directory: $hostpath" >&2
         exit 1
       fi
+      validate_path "$hostpath" "mount path"
       add_mount "$hostpath" "$hostpath" "$mode"
     done
 

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -365,14 +365,6 @@ pkgs.writeShellApplication {
         cp "$src" "$RUNDIR/$(basename "$src")"
       fi
     done
-    # Tool-specific extra dotfiles (e.g. shell rc files for the shell tool)
-    ${builtins.concatStringsSep "\n" (
-      map (f: ''
-        if [ -f "$HOME/${f}" ]; then
-          cp "$HOME/${f}" "$RUNDIR/${f}"
-        fi
-      '') (toolDefaults.extraDotfiles or [ ])
-    )}
     # SSH directory is NOT mounted by default — use --ro-mount ~/.ssh if needed
 
     # Mount host packages if available (NixOS host)

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -201,6 +201,16 @@ pkgs.writeShellApplication {
         fi
       done
 
+      # Forward host shell (resolved through symlinks so the /nix/store path
+      # is exposed, which the guest can reach via the 9p store mount even
+      # though /run/current-system/sw is remapped to /host-sw).
+      if [ -n "''${SHELL:-}" ]; then
+        RESOLVED_SHELL=$(readlink -f "$SHELL" 2>/dev/null || true)
+        if [ -n "$RESOLVED_SHELL" ]; then
+          echo "SHELL=\"$RESOLVED_SHELL\""
+        fi
+      fi
+
       # Forward AWS variables
       env | grep '^AWS_' || true
 
@@ -302,6 +312,9 @@ pkgs.writeShellApplication {
     fi
 
     validate_path "$CONFIG_DIR" "config directory"
+    # Ensure the config dir exists even when persistDirs is empty — 9p refuses
+    # to share a non-existent path.
+    mkdir -p "$CONFIG_DIR"
     # Mount config dir read-only with no cache (overlay lower layer)
     # cache=none ensures host-side credential refreshes are visible instantly
     add_mount "$CONFIG_DIR" "/home/user/${toolDefaults.configDirName}-ro" "ro-nocache"
@@ -352,6 +365,14 @@ pkgs.writeShellApplication {
         cp "$src" "$RUNDIR/$(basename "$src")"
       fi
     done
+    # Tool-specific extra dotfiles (e.g. shell rc files for the shell tool)
+    ${builtins.concatStringsSep "\n" (
+      map (f: ''
+        if [ -f "$HOME/${f}" ]; then
+          cp "$HOME/${f}" "$RUNDIR/${f}"
+        fi
+      '') (toolDefaults.extraDotfiles or [ ])
+    )}
     # SSH directory is NOT mounted by default — use --ro-mount ~/.ssh if needed
 
     # Mount host packages if available (NixOS host)

--- a/tools.nix
+++ b/tools.nix
@@ -25,6 +25,17 @@
       ];
     };
   };
+  shell = {
+    guestModule = ./guests/shell.nix;
+    defaults = {
+      mem = 2048; vcpu = 2;
+      configDirName = ".llmjail-shell";
+      persistDirs = [ ];
+      # No domains whitelisted by default — debug shell runs offline unless
+      # the user opts in with --allow-domain or --no-net-filter.
+      allowedDomains = [ ];
+    };
+  };
   copilot = {
     guestModule = ./guests/copilot.nix;
     defaults = {


### PR DESCRIPTION
- Reject paths containing commas, spaces, or colons (virtfs option injection / kernel cmdline truncation).
- Changes on netfilter to block even hardcoded ip access to outside.
- nix run .#shell (also llm-jail-shell) drops into the user's shell inside the sandbox for debugging the jail itself.
- Claude launcher pre-trusts /workspace in the guest's .claude.json so the "is this a project you trust?" prompt doesn't show up every run.
- Converted postMountCommands to a systemd-initrd service to make it work even in nixos 26.11.