### PR TITLE
Same-path workspace mounts and custom mount paths

### DIFF
--- a/guests/common.nix
+++ b/guests/common.nix
@@ -474,7 +474,7 @@
             ${pkgs.coreutils}/bin/stty cols "$COLUMNS" rows "$LINES" 2>/dev/null || true
           fi
 
-          cd /workspace
+          cd "''${WORKSPACE_DIR:-/workspace}"
           exec ${config.llmjail.toolBinary} "''${ARGS[@]}"
         '';
       in
@@ -486,7 +486,7 @@
         path = [ "/run/current-system/sw" ];
         serviceConfig = {
           User = "user";
-          WorkingDirectory = "/workspace";
+          WorkingDirectory = "-/workspace";
           EnvironmentFile = "/llmjail-env/env";
           StandardInput = "tty";
           StandardOutput = "tty";

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -28,6 +28,7 @@ pkgs.writeShellApplication {
     DANGEROUS=0
     DEV_ENV=0
     IMMUTABLE=0
+    SAME_PATH=0
     LLMJAIL_TMPDIR=''${TMPDIR:-/tmp}
     STORE_DISK=0
     NET_FILTER=1
@@ -52,9 +53,16 @@ pkgs.writeShellApplication {
       --profile NAME        State profile, a subdir of --state-dir/<tool> (default: default)
       --state-dir PATH      Jail state root dir (default: ~/.config/llm-jail)
       --immutable           Mount workspace as read-only instead of read-write
+      --same-path           Mount workspace at its host path instead of /workspace
+                             (lets tools like 'claude --resume' match sessions
+                             started outside the sandbox)
       --tmpdir PATH         Directory to use for runtime data (default: ''${TMPDIR:-/tmp})
-      --mount PATH          Extra read-write mount at same path in guest (repeatable)
-      --ro-mount PATH       Extra read-only mount at same path in guest (repeatable)
+      --mount HOSTPATH[:GUESTPATH]
+                             Extra read-write mount (repeatable). GUESTPATH
+                             defaults to HOSTPATH if omitted.
+      --ro-mount HOSTPATH[:GUESTPATH]
+                             Extra read-only mount (repeatable). GUESTPATH
+                             defaults to HOSTPATH if omitted.
       --mask GLOB           Mask paths matching GLOB in workspace/mounts (repeatable).
                             GLOB with '/' uses -path "<root>/GLOB" (matches across
                             subdirs, e.g. 'a/*' also hits 'a/b/c'); else -name GLOB.
@@ -100,6 +108,7 @@ pkgs.writeShellApplication {
         --ro-mount)    EXTRA_MOUNTS+=("$2:ro"); shift 2 ;;
         --tmpdir)      LLMJAIL_TMPDIR="$2"; shift 2 ;;
         --immutable)    IMMUTABLE=1; shift ;;
+        --same-path)   SAME_PATH=1; shift ;;
         --allow-domain)  EXTRA_DOMAINS+=("$2"); shift 2 ;;
         --no-net-filter) NET_FILTER=0; shift ;;
         --mask)        MASK_PATTERNS+=("$2"); shift 2 ;;
@@ -211,6 +220,11 @@ pkgs.writeShellApplication {
     }
     CLEANUP_FUNCS+=(cleanup_winch)
 
+    # ── Write env file ────────────────────────────────────────────────
+    WORKSPACE_DIR="/workspace"
+    if [[ "$SAME_PATH" -eq 1 ]]; then
+      WORKSPACE_DIR="$(pwd)"
+    fi
     ENV_FILE="$RUNDIR/env"
     {
       for var in ANTHROPIC_API_KEY ANTHROPIC_BASE_URL CLAUDE_CODE_MAX_OUTPUT_TOKENS OPENAI_API_KEY OPENAI_BASE_URL; do
@@ -249,6 +263,7 @@ pkgs.writeShellApplication {
       echo "LLMJAIL_DANGEROUS=$DANGEROUS"
       # Relocate the tool's state into the jail-private state mount
       echo "${toolDefaults.configEnvVar}=/home/user/${toolDefaults.configDirName}"
+      echo "WORKSPACE_DIR=\"$WORKSPACE_DIR\""
     } > "$ENV_FILE"
 
     # Write tool args as null-separated file to preserve argument boundaries
@@ -320,14 +335,14 @@ pkgs.writeShellApplication {
 
     validate_path "$(pwd)" "workspace path"
     if [[ "$IMMUTABLE" -eq 1 ]]; then
-      add_mount "$(pwd)" "/workspace" "ro-nocache"
+      add_mount "$(pwd)" "$WORKSPACE_DIR" "ro-nocache"
     else
-      add_mount "$(pwd)" "/workspace" "rw"
+      add_mount "$(pwd)" "$WORKSPACE_DIR" "rw"
       if [[ -d "$(pwd)/.git/hooks" ]]; then
-        add_mount "$(pwd)/.git/hooks" "/workspace/.git/hooks" "ro-nocache"
+        add_mount "$(pwd)/.git/hooks" "$WORKSPACE_DIR/.git/hooks" "ro-nocache"
       fi
     fi
-    MASK_ROOTS+=("/workspace")
+    MASK_ROOTS+=("$WORKSPACE_DIR")
 
     validate_path "$STATE_DIR" "state directory"
     # 9p refuses to share a non-existent path; first run starts empty and
@@ -354,15 +369,23 @@ pkgs.writeShellApplication {
 
     for spec in "''${EXTRA_MOUNTS[@]+"''${EXTRA_MOUNTS[@]}"}"; do
       if [ -z "$spec" ]; then continue; fi
-      hostpath="''${spec%:*}"
       mode="''${spec##*:}"
+      paths="''${spec%:*}"
+      if [[ "$paths" == *:* ]]; then
+        hostpath="''${paths%%:*}"
+        guestpath="''${paths#*:}"
+      else
+        hostpath="$paths"
+        guestpath="$paths"
+      fi
       if [ ! -d "$hostpath" ]; then
         echo "ERROR: mount path does not exist or is not a directory: $hostpath" >&2
         exit 1
       fi
       validate_path "$hostpath" "mount path"
-      add_mount "$hostpath" "$hostpath" "$mode"
-      MASK_ROOTS+=("$hostpath")
+      validate_path "$guestpath" "mount path"
+      add_mount "$hostpath" "$guestpath" "$mode"
+      MASK_ROOTS+=("$guestpath")
     done
 
     for p in "''${MASK_PATTERNS[@]+"''${MASK_PATTERNS[@]}"}"; do

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -220,7 +220,6 @@ pkgs.writeShellApplication {
     }
     CLEANUP_FUNCS+=(cleanup_winch)
 
-    # ── Write env file ────────────────────────────────────────────────
     WORKSPACE_DIR="/workspace"
     if [[ "$SAME_PATH" -eq 1 ]]; then
       WORKSPACE_DIR="$(pwd)"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -65,7 +65,7 @@ let
                 "systemctl show llmjail-tool.service -p User,WorkingDirectory"
             )
             assert "User=user" in output, f"Expected User=user in: {output}"
-            assert "WorkingDirectory=/workspace" in output, f"Expected WorkingDirectory=/workspace in: {output}"
+            assert "WorkingDirectory=-/workspace" in output, f"Expected WorkingDirectory=-/workspace in: {output}"
 
         with subtest("common packages are available"):
             machine.succeed("which git")

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -65,7 +65,7 @@ let
                 "systemctl show llmjail-tool.service -p User,WorkingDirectory"
             )
             assert "User=user" in output, f"Expected User=user in: {output}"
-            assert "WorkingDirectory=-/workspace" in output, f"Expected WorkingDirectory=-/workspace in: {output}"
+            assert "WorkingDirectory=!/workspace" in output, f"Expected WorkingDirectory=!/workspace in: {output}"
 
         with subtest("common packages are available"):
             machine.succeed("which git")


### PR DESCRIPTION
Add --same-path so the workspace mounts at its host path (needed for tools like `claude --resume` to match sessions started outside the sandbox), and let --mount/--ro-mount specify a distinct guest path.