### PR TITLE
fix: set guest user's id to real user's id

### DIFF
--- a/guests/common.nix
+++ b/guests/common.nix
@@ -153,6 +153,26 @@
       extraGroups = [ "tty" "dialout" "systemd-journal" ];
     };
 
+    users.mutableUsers = true;
+    systemd.services.llmjail-set-user-uid = {
+      wantedBy = [ "llmjail-mounts.service" ];
+      before = [ "llmjail-mounts.service" ];
+      script = ''
+        USER_UID=""
+        for arg in $(cat /proc/cmdline); do
+          case "$arg" in
+            llmjail.user_uid=*) USER_UID="''${arg#llmjail.user_uid=}" ;;
+          esac
+        done
+        if [[ -n "$USER_UID" && "$USER_UID" -ge 1000 ]] && ! ${pkgs.getent}/bin/getent passwd "$USER_UID"; then
+          ${pkgs.shadow}/bin/usermod -u "$USER_UID" user
+        fi
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+      };
+    };
+
     # ── llmjail-mounts service ───────────────────────────────────────────
     # Parses kernel cmdline for llmjail.mounts=tag0:/path:rw,tag1:/path:ro,...
     # and mounts each entry via 9p.

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -403,6 +403,10 @@ pkgs.writeShellApplication {
       KERNEL_PARAMS="$KERNEL_PARAMS llmjail.net_filter=1"
     fi
 
+    if USER_UID=''${EUID:-$(id -u)} && [[ -n "$USER_UID" ]]; then
+      KERNEL_PARAMS="$KERNEL_PARAMS llmjail.user_uid=$USER_UID"
+    fi
+
     # ── Store disk image ────────────────────────────────────────────
     DISK_ARGS=()
     if [ "$STORE_DISK" -gt 0 ]; then

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -371,8 +371,12 @@ pkgs.writeShellApplication {
     if [ -d /run/current-system/sw ]; then
       add_mount "/run/current-system/sw" "/host-sw" "ro"
     fi
-    if [ -d "/etc/profiles/per-user/$(whoami)" ]; then
-      add_mount "/etc/profiles/per-user/$(whoami)" "/host-user-sw" "ro"
+
+    # whoami from nixpkgs coreutils won't work on non-NixOS systems that have the user come from
+    # sssd and don't have nscd/nsncd enabled
+    USERNAME=$(whoami 2>/dev/null) || USERNAME="$USER"
+    if [ -n "$USERNAME" ] && [ -d "/etc/profiles/per-user/$USERNAME" ]; then
+      add_mount "/etc/profiles/per-user/$USERNAME" "/host-user-sw" "ro"
     fi
 
     # User extra mounts


### PR DESCRIPTION
Sets the id of `user` in the VM to the id of the user running llmjail. Mounted paths in the VM have
the ownership of the user that runs llmjail, so a mismatch does not allow the LLM tool to edit the
files.

Also adds reading `$USER` as a fallback to `whoami` in the mkRunner script, since `whoami` may fail
on non-NixOS systems where the user info is gotten via sssd

Tested changes on a machine with non-1000 uid user where the user comes via sssd, as well as on a
machine with regular user with uid 1000
