### PR TITLE
flake: update claude-code-nix, codex-cli-nix, llm-agents.nix, and autolith inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1785358275,
-        "narHash": "sha256-c6fu/1WY9cLomgJ8of/gnGiiTa/H+eMu/Yn1IRntw0g=",
+        "lastModified": 1785435580,
+        "narHash": "sha256-3LnnKjEIKE2zKQ3n1B6WcE9qim1LVa/Rjt31rjJPOJQ=",
         "owner": "luciusmagn",
         "repo": "autolith",
-        "rev": "d77f60679af58eb059c9f6dd5f1dd0a29bd2625c",
+        "rev": "b5ce0ec6d6323aa03e190dc6510233ed3c6179d6",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785393846,
-        "narHash": "sha256-ZrkupCDmDaM2lZZoOZ4bR5ioHBxyBdIUTSeXbx+383c=",
+        "lastModified": 1785481674,
+        "narHash": "sha256-ujzuafv52VH5LJkMINYcpjWG7xpMVHTZwwdiisJhZGY=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "ce99071da939d9d7997e27d35cf4d6c5e44bc32a",
+        "rev": "a6dcbf72f6d61519cc12858176f0fdd189853b28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated daily update of flake inputs:
- `claude-code-nix`
- `codex-cli-nix`
- `llm-agents.nix`
- `autolith`