### PR TITLE
Fix autolith configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supported tools:
 | [Codex CLI](https://github.com/openai/codex) | `llm-jail-codex` | `--dangerously-bypass-approvals-and-sandbox` |
 | [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | `llm-jail-copilot` | `--yolo` |
 | [opencode](https://opencode.ai) | `llm-jail-opencode` | `--auto` |
-| [Autolith](https://github.com/luciusmagn/autolith) (x86_64 only) | `llm-jail-autolith` | - |
+| [Autolith](https://github.com/luciusmagn/autolith) (x86_64 only) | `llm-jail-autolith` | `--permissions full` |
 | [Pi](https://pi.dev) | `llm-jail-pi` | - |
 | [oh-my-pi](https://omp.sh/) | `llm-jail-omp` | - |
 | Interactive shell (debugging) | `llm-jail-shell` | - |
@@ -63,7 +63,7 @@ nix run github:braiins/llm-jail#claude -- -- -p "Refactor the auth module" --max
 
 ## First run & authentication
 
-Each tool keeps its state in a jail-private directory on the host - `~/.config/llm-jail/<tool>/<profile>` (profile `default` unless `--profile` is given) - mounted read-write into the guest and selected via the tool's native relocation variable (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `COPILOT_HOME`, `AUTOLITH_HOME`, `XDG_DATA_HOME` for opencode, or `PI_CODING_AGENT_DIR` for Pi). Your real `~/.claude`, `~/.codex`, `~/.copilot`, `~/.local/share/opencode`, and `~/.pi` are never mounted or read.
+Each tool keeps its state in a jail-private directory on the host - `~/.config/llm-jail/<tool>/<profile>` (profile `default` unless `--profile` is given) - mounted read-write into the guest and selected via the tool's native relocation variable (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `COPILOT_HOME`, Autolith's XDG roots plus `CODEX_HOME`/`GROK_HOME`, `XDG_DATA_HOME` for opencode, or `PI_CODING_AGENT_DIR` for Pi). Your real `~/.claude`, `~/.codex`, `~/.copilot`, `~/.local/share/opencode`, and `~/.pi` are never mounted or read.
 
 On first run the directory is empty, so the tool walks you through its normal login flow in the terminal (the OAuth paste-a-URL flow works as-is). Credentials, settings, and session history then persist across runs. Copilot on headless Linux will ask to store its token in plaintext inside the config dir - that's expected, there is no keychain in the guest. opencode doesn't prompt by itself - log in once with `nix run .#opencode -- -- auth login`. Authenticate Autolith explicitly with `nix run .#autolith -- -- --auth`; its first launch also builds pinned recovery and active Lisp images offline in the private state directory. Pi has no explicit login command - launch it once with `nix run .#pi` and use its built-in `/login` flow; credentials persist in the jail-private state directory.
 
@@ -170,7 +170,7 @@ The shell tool honors `$SHELL` (resolved through symlinks so the `/nix/store` pa
 **Filesystem.** The guest boots on a tmpfs root. Only explicitly mounted directories are visible:
 
 - The current working directory -> `/workspace` (read-write)
-- The jail-private tool state dir `~/.config/llm-jail/<tool>/<profile>` -> `/home/user/.claude`, `.codex`, `.copilot`, `.opencode`, `.autolith`, `.pi`, or `.shell` (read-write; the tool is pointed at it via `CLAUDE_CONFIG_DIR`/`CODEX_HOME`/`COPILOT_HOME`/`XDG_DATA_HOME`/`AUTOLITH_HOME`/`PI_CODING_AGENT_DIR`/`ZDOTDIR`)
+- The jail-private tool state dir `~/.config/llm-jail/<tool>/<profile>` -> `/home/user/.claude`, `.codex`, `.copilot`, `.opencode`, `.autolith`, `.pi`, or `.shell` (read-write; Autolith uses its XDG roots plus `CODEX_HOME`/`GROK_HOME`; the other tools use `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `COPILOT_HOME`, `XDG_DATA_HOME`, `PI_CODING_AGENT_DIR`, or `ZDOTDIR`)
 - `~/.gitconfig` is copied in (9p cannot mount single files)
 - Host system and user packages -> `/host-sw`, `/host-user-sw` (read-only, NixOS hosts only)
 - Any directories added via `--mount` / `--ro-mount`

--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1786144358,
-        "narHash": "sha256-/S86aUatgmGRTEssXFbfd92+bYxhlP0FzCpSWPmrIJ0=",
+        "lastModified": 1786195013,
+        "narHash": "sha256-ESiQeswZSqB4Q32dZblvnw0VOAhjs5s+YL/hbfZNRtY=",
         "owner": "luciusmagn",
         "repo": "autolith",
-        "rev": "4b7cae5b9949027b0253a66ecaff0e688be6a337",
+        "rev": "17fc2142c77cef45df6cdfb8d0dec8f2ee452c0a",
         "type": "github"
       },
       "original": {

--- a/guests/autolith.nix
+++ b/guests/autolith.nix
@@ -1,11 +1,19 @@
-{ autolith, ... }:
+{ pkgs, autolith, ... }:
 
 {
   imports = [ ./common.nix ];
 
-  llmjail.toolBinary = "${autolith}/bin/autolith";
-  # Autolith has no permission-prompt mode, so --dangerous is a no-op.
-  llmjail.dangerousFlag = "";
+  llmjail.toolBinary = pkgs.writeShellScript "autolith-launcher" ''
+    export XDG_CONFIG_HOME="$AUTOLITH_HOME/config"
+    export XDG_DATA_HOME="$AUTOLITH_HOME/data"
+    export XDG_STATE_HOME="$AUTOLITH_HOME/state"
+    export XDG_CACHE_HOME="$AUTOLITH_HOME/cache"
+    export CODEX_HOME="$AUTOLITH_HOME/codex"
+    export GROK_HOME="$AUTOLITH_HOME/grok"
+    exec ${autolith}/bin/autolith "$@"
+  '';
+
+  llmjail.dangerousFlag = "--permissions full";
 
   environment.systemPackages = [ autolith ];
 }

--- a/tools.nix
+++ b/tools.nix
@@ -76,7 +76,7 @@
     defaults = {
       mem = 4096;
       vcpu = 2;
-      configDirName = ".autolith";
+      configDirName = ".config/autolith";
       configEnvVar = "AUTOLITH_HOME";
       allowedDomains = [
         "auth.openai.com"


### PR DESCRIPTION
I moved autolith's configuration to use XDG spec directories instead of storing the information in ~/.autolith
After this, I did not update the llm jail configuration, and on subsequent releases of autolith; configuration, authentication, etc would not persist across sessions.