### PR TITLE
fix: source /etc/set-environment for env vars, pass ctrl+c to VM

### DIFF
--- a/guests/common.nix
+++ b/guests/common.nix
@@ -430,8 +430,11 @@
     systemd.services.llmjail-tool =
       let
         launcher = pkgs.writeShellScript "launch-tool" ''
-          set -euo pipefail
+          # Source NixOS's global environment before modifying env vars. Must be sourced before
+          # `set -u` since some variables such as `XDG_STATE_HOME` may not be set.
+          source /etc/set-environment
 
+          set -euo pipefail
           # Add host packages to PATH if available (NixOS host)
           if [ -d /host-user-sw/bin ]; then
             export PATH="/host-user-sw/bin:$PATH"
@@ -439,15 +442,6 @@
           if [ -d /host-sw/bin ]; then
             export PATH="/host-sw/bin:$PATH"
           fi
-
-          # nixpkgs zsh bakes a global zshenv into its own store path, so a
-          # forwarded host $SHELL sources it even though the guest has no
-          # /etc/zshenv. Unless this guard is set, that zshenv sources the
-          # guest's /etc/set-environment in every `zsh -c`, which REPLACES
-          # PATH with the guest session default - silently dropping the
-          # /host-sw, /host-user-sw, and dev-env entries above. The bash
-          # login path (/etc/profile) honors the same guard.
-          export __NIXOS_SET_ENVIRONMENT_DONE=1
 
           if [ -f /llmjail-env/dev-env ]; then
             # dev-env is output of `nix print-dev-env` - a bash script setting PATH, etc.

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -475,7 +475,7 @@ pkgs.writeShellApplication {
       -initrd ${toplevel}/initrd \
       -append "$KERNEL_PARAMS" \
       -display none \
-      -chardev stdio,id=cons0,mux=on \
+      -chardev stdio,id=cons0,mux=on,signal=off \
       -mon chardev=cons0,mode=readline \
       -device virtio-serial-pci \
       -device virtconsole,chardev=cons0,nr=0 \


### PR DESCRIPTION
Not sourcing /etc/set-environment means env vars set in the config (such as NIX_PATH) are never set.
Previously was skipped because it overwrote PATH, but just source it before changing PATH

signal=off means terminal codes like CTRL+C get passed into the VM, instead of QEMU taking it and
shutting itself down
