### PR TITLE
Initialize the Nix db to system closure, use updated nixpkgs for registry + NIX_PATH

### DIFF
--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Update flake inputs
         run: |
           {
+            nix flake update nixpkgs-rolling
             nix flake update claude-code-nix
             nix flake update codex-cli-nix
             nix flake update llm-agents
@@ -34,12 +35,13 @@ jobs:
         with:
           token: ${{ secrets.PR_TOKEN }}
           commit-message: |
-            flake: update claude-code-nix, codex-cli-nix, llm-agents.nix, nix-omp, and autolith inputs
+            flake: update nixpkgs-rolling, claude-code-nix, codex-cli-nix, llm-agents.nix, nix-omp, and autolith inputs
 
             ${{ env.UPDATE_OUTPUT }}
-          title: "flake: update claude-code-nix, codex-cli-nix, llm-agents.nix, nix-omp, and autolith inputs"
+          title: "flake: update nixpkgs-rolling, claude-code-nix, codex-cli-nix, llm-agents.nix, nix-omp, and autolith inputs"
           body: |
             Automated daily update of flake inputs:
+            - `nixpkgs-rolling`
             - `claude-code-nix`
             - `codex-cli-nix`
             - `llm-agents.nix`

--- a/flake.lock
+++ b/flake.lock
@@ -224,6 +224,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-rolling": {
+      "locked": {
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1785747939,
@@ -311,7 +327,8 @@
         "codex-cli-nix": "codex-cli-nix",
         "llm-agents": "llm-agents",
         "nix-omp": "nix-omp",
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_6",
+        "nixpkgs-rolling": "nixpkgs-rolling"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # Nixpkgs that is pinned in NIX_PATH and flake registry in the VM, should be up to date
+    nixpkgs-rolling.url = "github:NixOS/nixpkgs/nixos-unstable";
     claude-code-nix.url = "github:sadjow/claude-code-nix";
     codex-cli-nix.url = "github:sadjow/codex-cli-nix";
     llm-agents.url = "github:numtide/llm-agents.nix";
@@ -10,7 +13,7 @@
     nix-omp.url = "github:jamtur01/nix-omp";
   };
 
-  outputs = { self, nixpkgs, claude-code-nix, codex-cli-nix, llm-agents, autolith, nix-omp, ... }@inputs:
+  outputs = { self, nixpkgs, nixpkgs-rolling, claude-code-nix, codex-cli-nix, llm-agents, autolith, nix-omp, ... }@inputs:
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
       tools = import ./tools.nix;
@@ -53,6 +56,7 @@
               specialArgs = {
                 inherit
                   nixpkgs
+                  nixpkgs-rolling
                   claude-code
                   codex-cli
                   copilot-cli
@@ -88,7 +92,7 @@
 
       checks = forAllSystems (system:
         import ./tests {
-          inherit nixpkgs;
+          inherit nixpkgs nixpkgs-rolling;
           pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -427,6 +427,42 @@
       '';
     };
 
+    # mostly copied from similar service in nixpkgs/nixos/modules/virtualisation/qemu-vm.nix
+    systemd.services.register-nix-paths = {
+      unitConfig.DefaultDependencies = false;
+      wantedBy = [ "sysinit.target" ];
+
+      before = [
+        "sysinit.target"
+        "shutdown.target"
+        "nix-daemon.socket"
+        "nix-daemon.service"
+      ];
+      after = [
+        "local-fs.target"
+      ];
+      conflicts = [
+        "shutdown.target"
+      ];
+      restartIfChanged = false;
+      script = ''
+        NIX_DB_DUMP=""
+        for arg in $(cat /proc/cmdline); do
+          case "$arg" in
+            llmjail.nix_db_dump=*) NIX_DB_DUMP="''${arg#llmjail.nix_db_dump=}" ;;
+          esac
+        done
+
+        if [[ -z "$NIX_DB_DUMP" ]]; then
+          echo "<4> No Nix db dump specified (llmjail.nix_db_dump), not loading Nix db"
+          exit 1
+        fi
+
+        ${lib.getExe' config.nix.package "nix-store"} --load-db < "$NIX_DB_DUMP"
+      '';
+    };
+
+
     systemd.services.llmjail-tool =
       let
         launcher = pkgs.writeShellScript "launch-tool" ''

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -112,10 +112,16 @@
     # /nix/store overlay and /nix/var bind-mount are done by the
     # llmjail-store-overlay initrd service (above) which orders itself
     # after the 9p lower layer is mounted.
+    # /llmjail-env: small config files plus the host nix db snapshot.
+    # cache=loose (same as the store lower mount below): the share is
+    # read-only and its files are immutable during the run, and loose
+    # enables client readahead. cache=none serializes every 9p read
+    # request-by-request, which made installing the multi-MB db snapshot
+    # take seconds.
     fileSystems."/llmjail-env" = {
       device = "envfs";
       fsType = "9p";
-      options = [ "trans=virtio" "version=9p2000.L" "cache=none" "msize=1048576" "ro" ];
+      options = [ "trans=virtio" "version=9p2000.L" "cache=loose" "msize=1048576" "ro" ];
       neededForBoot = true;
     };
 
@@ -427,7 +433,14 @@
       '';
     };
 
-    # mostly copied from similar service in nixpkgs/nixos/modules/virtualisation/qemu-vm.nix
+    # Register the host store's paths in the guest nix db before the
+    # nix-daemon starts. Preferred source is a snapshot of the host's
+    # /nix/var/nix/db/db.sqlite (llmjail.nix_db_snapshot, taken by the
+    # runner via `sqlite3 .backup` and shipped through the envfs share):
+    # installing the file takes milliseconds, vs minutes for --load-db of
+    # a big store. Falls back to the toplevel closure registration dump
+    # (llmjail.nix_db_dump) when no snapshot is available. Mostly copied
+    # from nixpkgs/nixos/modules/virtualisation/qemu-vm.nix.
     systemd.services.register-nix-paths = {
       unitConfig.DefaultDependencies = false;
       wantedBy = [ "sysinit.target" ];
@@ -446,19 +459,29 @@
       ];
       restartIfChanged = false;
       script = ''
+        NIX_DB_SNAPSHOT=""
         NIX_DB_DUMP=""
         for arg in $(cat /proc/cmdline); do
           case "$arg" in
+            llmjail.nix_db_snapshot=*) NIX_DB_SNAPSHOT="''${arg#llmjail.nix_db_snapshot=}" ;;
             llmjail.nix_db_dump=*) NIX_DB_DUMP="''${arg#llmjail.nix_db_dump=}" ;;
           esac
         done
 
-        if [[ -z "$NIX_DB_DUMP" ]]; then
-          echo "<4> No Nix db dump specified (llmjail.nix_db_dump), not loading Nix db"
+        if [[ -n "$NIX_DB_SNAPSHOT" ]] && [[ -s "$NIX_DB_SNAPSHOT" ]]; then
+          echo "Installing host nix db snapshot ($NIX_DB_SNAPSHOT)"
+          ${pkgs.coreutils}/bin/mkdir -p /nix/var/nix/db
+          # Drop leftover WAL state from a previous boot on a persistent
+          # store disk; the snapshot is a clean standalone db.
+          ${pkgs.coreutils}/bin/rm -f /nix/var/nix/db/db.sqlite-wal /nix/var/nix/db/db.sqlite-shm
+          ${pkgs.coreutils}/bin/install -m 0644 "$NIX_DB_SNAPSHOT" /nix/var/nix/db/db.sqlite
+        elif [[ -n "$NIX_DB_DUMP" ]]; then
+          echo "Loading closure nix db dump ($NIX_DB_DUMP)"
+          ${lib.getExe' config.nix.package "nix-store"} --load-db < "$NIX_DB_DUMP"
+        else
+          echo "<4> No Nix db snapshot or dump specified, not initializing Nix db"
           exit 1
         fi
-
-        ${lib.getExe' config.nix.package "nix-store"} --load-db < "$NIX_DB_DUMP"
       '';
     };
 

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, nixpkgs, ... }:
+{ config, lib, pkgs, nixpkgs-rolling, ... }:
 
 {
   options.llmjail = {
@@ -540,9 +540,11 @@
     nix.settings.sandbox = false;
 
     # Pin nixpkgs within the VM.
-    nix.registry.nixpkgs.flake = nixpkgs;
-    nix.nixPath = [ "nixpkgs=${pkgs.path}" ];
-    nix.settings.nix-path = [ "nixpkgs=${pkgs.path}" ];
+    nix.registry.nixpkgs.to = {
+      type = "path";
+      path = nixpkgs-rolling;
+    };
+    nix.nixPath = [ "nixpkgs=${nixpkgs-rolling}" ];
 
     system.stateVersion = "24.11";
   };

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -7,6 +7,7 @@
 
 let
   toplevel = guest.config.system.build.toplevel;
+  toplevelDbDump = pkgs.closureInfo { rootPaths = [ toplevel ]; };
   qemuPkg = pkgs.qemu_kvm;
   arch = if pkgs.stdenv.hostPlatform.isx86_64 then "x86_64" else "aarch64";
 in
@@ -417,6 +418,8 @@ pkgs.writeShellApplication {
     if USER_UID=''${EUID:-$(id -u)} && [[ -n "$USER_UID" ]]; then
       KERNEL_PARAMS="$KERNEL_PARAMS llmjail.user_uid=$USER_UID"
     fi
+
+    KERNEL_PARAMS="$KERNEL_PARAMS llmjail.nix_db_dump=${toplevelDbDump}/registration"
 
     DISK_ARGS=()
     if [ "$STORE_DISK" -gt 0 ]; then

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -21,6 +21,7 @@ pkgs.writeShellApplication {
     pkgs.e2fsprogs
     pkgs.pv
     pkgs.socat
+    pkgs.sqlite
   ];
   text = ''
     set -euo pipefail
@@ -356,6 +357,19 @@ pkgs.writeShellApplication {
       cp "$HOME/.gitconfig" "$RUNDIR/.gitconfig"
     fi
 
+    # Snapshot the host nix db into the envfs share so the guest can register the whole host store
+    # without replaying rows through `nix-store --load-db` (minutes for big stores). `.backup` is
+    # safe against the live nix-daemon and includes uncheckpointed WAL state. Skipped when the host
+    # has no local nix db (the guest then falls back to the toplevel closure dump).
+    NIX_DB_SNAPSHOT=""
+    if [ -f /nix/var/nix/db/db.sqlite ]; then
+      if sqlite3 /nix/var/nix/db/db.sqlite ".backup $RUNDIR/nix-db.sqlite" 2>/dev/null; then
+        NIX_DB_SNAPSHOT="/llmjail-env/nix-db.sqlite"
+      else
+        echo "WARNING: could not snapshot host nix db, falling back to closure dump" >&2
+      fi
+    fi
+
     # Mount host packages if available (NixOS host)
     if [ -d /run/current-system/sw ]; then
       add_mount "/run/current-system/sw" "/host-sw" "ro"
@@ -417,6 +431,10 @@ pkgs.writeShellApplication {
 
     if USER_UID=''${EUID:-$(id -u)} && [[ -n "$USER_UID" ]]; then
       KERNEL_PARAMS="$KERNEL_PARAMS llmjail.user_uid=$USER_UID"
+    fi
+
+    if [ -n "$NIX_DB_SNAPSHOT" ]; then
+      KERNEL_PARAMS="$KERNEL_PARAMS llmjail.nix_db_snapshot=$NIX_DB_SNAPSHOT"
     fi
 
     KERNEL_PARAMS="$KERNEL_PARAMS llmjail.nix_db_dump=${toplevelDbDump}/registration"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nixpkgs, claude-code, codex-cli, copilot-cli, opencode, omp, autolith ? null, pi-coding-agent ? null }:
+{ pkgs, nixpkgs, nixpkgs-rolling, claude-code, codex-cli, copilot-cli, opencode, omp, autolith ? null, pi-coding-agent ? null }:
 
 let
   mkSmokeTest = { name, guestModule, toolBinary }:
@@ -7,7 +7,7 @@ let
 
       nodes.machine = { lib, ... }: {
         imports = [ guestModule ];
-        _module.args = { inherit nixpkgs claude-code codex-cli copilot-cli opencode omp autolith pi-coding-agent; };
+        _module.args = { inherit nixpkgs nixpkgs-rolling claude-code codex-cli copilot-cli opencode omp autolith pi-coding-agent; };
         # Override 9p filesystem entries from common.nix - the test framework
         # provides its own root and /nix/store via virtualisation options.
         fileSystems."/.nix-lower/store" = lib.mkForce {
@@ -84,13 +84,6 @@ let
         with subtest("nixpkgs is pinned in registry and search path"):
             machine.succeed("cat /etc/nix/registry.json | grep nixpkgs")
             machine.succeed("nix-instantiate --eval -E '<nixpkgs>'")
-            # The tool service never sources /etc/set-environment (launch-tool
-            # sets __NIXOS_SET_ENVIRONMENT_DONE=1 to keep the host-package PATH
-            # entries), so <nixpkgs> resolution must come from the nix.conf
-            # nix-path setting, not the NIX_PATH session variable.
-            machine.succeed(
-                "env -u NIX_PATH __NIXOS_SET_ENVIRONMENT_DONE=1 nix-instantiate --eval -E '<nixpkgs>'"
-            )
         with subtest("user can read kernel journal"):
             machine.succeed("su - user -c 'journalctl -k --no-pager -n 1'")
       '';
@@ -101,7 +94,7 @@ let
 
     nodes.machine = { lib, ... }: {
       imports = [ ../guests/claude.nix ];
-      _module.args = { inherit nixpkgs claude-code codex-cli; };
+      _module.args = { inherit nixpkgs nixpkgs-rolling claude-code codex-cli; };
 
       fileSystems."/.nix-lower/store" = lib.mkForce {
         device = "tmpfs";


### PR DESCRIPTION
Depends on #98 for the set-environment change

Previously the nix db was uninitialized, which meant that even though the paths were there, Nix
didn't know about them and would thus act like they didn't exist for the purpose of evals/builds.
For example, running `nix flake show nixpkgs` in the VM would have Nix try to copy the pinned
nixpkgs into the store, even though it was already in the store.

The DB would ideally be initialized to match the host's DB, but it's quite slow to load a big
store's db. My laptop with a 73G store produced a db dump of 38M, which took 1min 30s to load. The
dump of the closure takes a couple hundred milliseconds
