### PR TITLE
flake: update nixpkgs-rolling, claude-code-nix, codex-cli-nix, llm-agents.nix, nix-omp, and autolith inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1786243682,
-        "narHash": "sha256-tigl1F76JwBMNhYXgWnkVxAWTv1BkJtiUvfv7nonfvk=",
+        "lastModified": 1786322124,
+        "narHash": "sha256-Flnf6nEvWvz1hkuWEym+o8D5stN50nrFcWEy69Sxpyc=",
         "owner": "luciusmagn",
         "repo": "autolith",
-        "rev": "42649b525512157018646512a256e8ee5342f583",
+        "rev": "8755dc516c9f6c1126b148d3fc426312095de871",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786252007,
-        "narHash": "sha256-B43/S2NVWQ3CJslyQPkvKQzkEgZLzYpyZr3iGiQZHEo=",
+        "lastModified": 1786337855,
+        "narHash": "sha256-UG8v0D6MCJs7TCpdpAOLKus+IHktnt4MlV19kFLZQ2w=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "2c27c5fcb51edf0ac740e944c2c357016d9ea2d9",
+        "rev": "33656317a15ef8171dc2efbbdefd5f7b092b57b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated daily update of flake inputs:
- `nixpkgs-rolling`
- `claude-code-nix`
- `codex-cli-nix`
- `llm-agents.nix`
- `autolith`
- `nix-omp`