### PR TITLE
feat: system for flags required at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ llm-jail-{claude,codex,copilot,opencode,autolith,pi,shell} [options] [-- tool-ar
 
 Press **Ctrl-a x** to force-quit QEMU at any time.
 
+### Nix build-time 'arguments'
+Some features may need to be added at build-time for the VM itself, and can thus not be enabled with
+simple script --flags. For such features we have a way to easily pass 'arguments' to the tool before
+it builds itself. This is done by specifying a nested attribute that corresponds to a defined
+argument in the tool you want to use. The arguments can be specified in any order. For example:
+```bash
+# Runs the base claude tool with no build-time arguments
+nix run .#claude
+
+# Runs the claude tool with argument `devenv`, which then gets used to modify the build
+nix run .#claude.devenv
+
+# Run with arguments `foo` and `devenv`
+nix run .#claude.foo.devenv
+```
+
+| Argument | Description |
+|----------|-------------|
+| `devenv` | Adds `devenv` to the runner script's PATH |
+
 ### Examples
 
 Run Claude in dangerous mode for a fully autonomous task:
@@ -134,7 +154,7 @@ Use a devenv.sh shell inside the VM (requires `--same-path`, since devenv
 bakes the workspace's absolute host path into its environment):
 
 ```bash
-nix run .#claude -- --devenv --same-path -- -p "Run the test suite"
+nix run .#claude.devenv -- --devenv --same-path -- -p "Run the test suite"
 ```
 
 Allow access to additional domains (e.g. for package installs or git cloning):

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,10 @@
           (_: def: builtins.elem system (def.systems or supportedSystems))
           tools;
 
+      flags = { };
+      apply = package: setFlags: package.override { flags = setFlags; };
+      addFlags = import ./lib/addFlags.nix;
+
       mkTool = system: toolName: toolDef:
         let
           pkgs = nixpkgs.legacyPackages.${system};
@@ -39,8 +43,7 @@
             pi-coding-agent = llm-agents.packages.${system}.pi;
             omp = nix-omp.packages.${system}.default;
           };
-        in
-        pkgs.lib.makeOverridable (
+          tool = pkgs.lib.makeOverridable (
           {
             claude-code,
             codex-cli,
@@ -49,6 +52,7 @@
             autolith,
             pi-coding-agent,
             omp,
+            flags ? { },
           }:
           let
             guest = nixpkgs.lib.nixosSystem {
@@ -72,11 +76,13 @@
               ];
             };
           in import ./lib/mkRunner.nix {
-            inherit pkgs guest;
+            inherit pkgs guest flags;
             name = toolName;
             toolDefaults = toolDef.defaults;
           }
         ) defaultArgs;
+        in
+          addFlags tool flags apply;
 
     in {
       packages = forAllSystems (system:

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,9 @@
           (_: def: builtins.elem system (def.systems or supportedSystems))
           tools;
 
-      flags = { };
+      flags = {
+        devenv = true;
+      };
       apply = package: setFlags: package.override { flags = setFlags; };
       addFlags = import ./lib/addFlags.nix;
 

--- a/lib/addFlags.nix
+++ b/lib/addFlags.nix
@@ -1,0 +1,20 @@
+package: allFlags: apply:
+let
+  applyFlags =
+    pkg: consumed:
+    let
+      leftover = removeAttrs allFlags (builtins.attrNames consumed);
+    in
+    pkg.overrideAttrs (o: {
+      passthru =
+        (o.passthru or { })
+        // (builtins.mapAttrs (key: value: recursion (consumed // { ${key} = value; })) leftover);
+    });
+  recursion =
+    consumed:
+    let
+      applied = apply package consumed;
+    in
+    if consumed != allFlags then applyFlags applied consumed else applied;
+in
+applyFlags package { }

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -7,6 +7,7 @@
 }:
 
 let
+  inherit (pkgs) lib;
   toplevel = guest.config.system.build.toplevel;
   toplevelDbDump = pkgs.closureInfo { rootPaths = [ toplevel ]; };
   qemuPkg = pkgs.qemu_kvm;
@@ -19,12 +20,12 @@ pkgs.writeShellApplication {
     pkgs.coreutils
     pkgs.util-linux
     pkgs.nix
-    pkgs.devenv
     pkgs.e2fsprogs
     pkgs.pv
     pkgs.socat
     pkgs.sqlite
-  ];
+  ]
+  ++ (lib.optional (flags ? devenv) pkgs.devenv);
   text = ''
     set -euo pipefail
 
@@ -285,9 +286,7 @@ pkgs.writeShellApplication {
 
     if [ "$NET_FILTER" = "1" ]; then
       {
-        ${builtins.concatStringsSep "\n    " (
-          map (d: "echo \"${d}\"") toolDefaults.allowedDomains
-        )}
+        ${builtins.concatStringsSep "\n    " (map (d: "echo \"${d}\"") toolDefaults.allowedDomains)}
 
         # Auto-extract domains from base URL env vars
         for var in ANTHROPIC_BASE_URL OPENAI_BASE_URL; do
@@ -308,6 +307,13 @@ pkgs.writeShellApplication {
       } | sort -u > "$RUNDIR/allowed-domains"
     else
       : > "$RUNDIR/allowed-domains"
+    fi
+
+    if [ "$DEVENV" = "1" ] && ! command -v devenv >/dev/null; then
+      echo "ERROR: --devenv requires the 'devenv' CLI, which was not found" >&2
+      echo "You can add it to the tool by using, for example," >&2
+      echo "'packages.x86_64-linux.claude.devenv' instead of 'packages.x86_64-linux.claude'"
+      exit 1
     fi
 
     if [ "$NIX_ENV" = "1" ] && [ "$DEVENV" = "1" ]; then

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -1,8 +1,9 @@
-{ pkgs
-, name
-, guest
-, toolDefaults
-,
+{
+  pkgs,
+  name,
+  guest,
+  toolDefaults,
+  flags,
 }:
 
 let


### PR DESCRIPTION
This allows making arguments that decide how the package itself gets built, such as whether to add a
specific package to the script closure or whether to enable a specific NixOS module for the VM.

Doing this means more features can get added without worrying too much over the closure size of the
base tool exploding for usecases that may not be too common.

Use this system to only add `devenv` to the mkRunner script if passed as an arg
