### PR TITLE
Support Apple Silicon Darwin guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # llm-jail
 
-Hardware-level sandbox for running coding agents inside QEMU microVMs. No containers, no disk images - each session boots a minimal NixOS guest on tmpfs with the host Nix store shared read-only.
+Hardware-level sandbox for running coding agents inside Linux microVMs. No containers or root disk images are needed. Each session boots a minimal NixOS guest on tmpfs with the host Nix store shared read-only.
 
 Supported tools:
 
@@ -10,18 +10,25 @@ Supported tools:
 | [Codex CLI](https://github.com/openai/codex) | `llm-jail-codex` | `--dangerously-bypass-approvals-and-sandbox` |
 | [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | `llm-jail-copilot` | `--yolo` |
 | [opencode](https://opencode.ai) | `llm-jail-opencode` | `--auto` |
-| [Autolith](https://github.com/luciusmagn/autolith) (x86_64 only) | `llm-jail-autolith` | `--permissions full` |
+| [Autolith](https://github.com/luciusmagn/autolith) | `llm-jail-autolith` | `--permissions full` |
 | [Pi](https://pi.dev) | `llm-jail-pi` | - |
 | [oh-my-pi](https://omp.sh/) | `llm-jail-omp` | - |
 | Interactive shell (debugging) | `llm-jail-shell` | - |
 
 ## Requirements
 
-- Linux (x86_64 or aarch64)
+- Linux (x86_64 or aarch64), or Apple Silicon macOS
 - [Nix](https://nixos.org/) with flakes enabled
-- KVM access recommended (falls back to emulation without it)
+- KVM access recommended on Linux (falls back to emulation without it)
+- Virtualization.framework on macOS 13 or newer
+- A Linux builder or binary cache that can supply the `aarch64-linux` guest closure on macOS
 
 No host-side tool credentials are needed: you log in once inside the jail on first run, and the tool's state persists in a jail-private directory under `~/.config/llm-jail/` (see [First run & authentication](#first-run--authentication)).
+
+Apple Silicon currently exposes the `claude`, `autolith`, and `shell` runners.
+The flake keeps its declared inputs intact. Darwin builds the ordinary
+`aarch64-linux` guest through the configured builder or substitutes it from a
+cache, then runs it locally through Virtualization.framework.
 
 ## Quick start
 
@@ -47,7 +54,7 @@ nix run github:braiins/llm-jail#pi
 # Run oh-my-pi
 nix run github:braiins/llm-jail#omp
 
-# Authenticate Autolith, then run it (x86_64 Linux only)
+# Authenticate Autolith, then run it
 nix run github:braiins/llm-jail#autolith -- -- --auth
 nix run github:braiins/llm-jail#autolith
 
@@ -90,6 +97,7 @@ llm-jail-{claude,codex,copilot,opencode,autolith,pi,shell} [options] [-- tool-ar
 | `--profile NAME` | State profile, a subdir of `--state-dir/<tool>` | `default` |
 | `--state-dir PATH` | Jail state root dir, mounted read-write | `~/.config/llm-jail` |
 | `--immutable` | Mount workspace as read-only | off |
+| `--supervisor-socket PATH` | Connect a guest serial device to an existing host Unix socket | - |
 | `--tmpdir PATH` | Directory to use for runtime data | `${TMPDIR:-/tmp}` |
 | `--mount PATH` | Extra read-write mount (repeatable) | - |
 | `--ro-mount PATH` | Extra read-only mount (repeatable) | - |
@@ -102,7 +110,7 @@ llm-jail-{claude,codex,copilot,opencode,autolith,pi,shell} [options] [-- tool-ar
 | `--vcpu COUNT` | Number of vCPUs | 2 |
 | `-h`, `--help` | Show help | - |
 
-Press **Ctrl-a x** to force-quit QEMU at any time.
+Press **Ctrl-c** to stop the VM on macOS. Press **Ctrl-a x** to force-quit QEMU on Linux.
 
 ### Examples
 
@@ -149,6 +157,22 @@ Disable network filtering entirely:
 nix run .#claude -- --no-net-filter
 ```
 
+### Supervisor socket
+
+`--supervisor-socket /absolute/path` connects a private guest serial device to
+an existing host `AF_UNIX` stream listener. The listener must create and listen
+on the socket before llm-jail starts. Inside the guest,
+`LLMJAIL_SUPERVISOR_DEVICE` names the device: the QEMU backend uses
+`/dev/virtio-ports/llmjail.supervisor` and the VZ backend uses `/dev/hvc1`.
+
+This is a policy-free byte transport. llm-jail does not define message framing,
+register operations, authenticate requests, launch handlers, or inspect the
+traffic. The listener owns the complete protocol and must treat every byte from
+the guest as hostile. It must validate and authorize requests, bound resource
+use, keep credentials out of responses, and close the socket when the session
+ends. The host socket path is not published in the guest. Without this option,
+no supervisor serial device is attached and the environment variable is unset.
+
 Run `nix build` inside the VM with extra storage (root tmpfs is only 2G):
 
 ```bash
@@ -163,7 +187,7 @@ nix run .#shell -- --allow-domain github.com # opt in to specific domains
 nix run .#shell -- --no-net-filter           # full network for debugging
 ```
 
-The shell tool honors `$SHELL` (resolved through symlinks so the `/nix/store` path is used) and falls back to zsh or bash if the host shell isn't reachable inside the guest (e.g. on non-NixOS hosts). Shell rc files are not copied in; bring anything you need with `--ro-mount`.
+On Linux, the shell tool honors `$SHELL` (resolved through symlinks so the `/nix/store` path is used) and falls back to zsh or bash if the host shell isn't reachable inside the guest. On macOS it uses the guest's Nix-built zsh or bash because Darwin binaries cannot execute in the Linux guest. Shell rc files are not copied in; bring anything you need with `--ro-mount`.
 
 ## What's isolated
 
@@ -171,7 +195,7 @@ The shell tool honors `$SHELL` (resolved through symlinks so the `/nix/store` pa
 
 - The current working directory -> `/workspace` (read-write)
 - The jail-private tool state dir `~/.config/llm-jail/<tool>/<profile>` -> `/home/user/.claude`, `.codex`, `.copilot`, `.opencode`, `.autolith`, `.pi`, or `.shell` (read-write; Autolith uses its XDG roots plus `CODEX_HOME`/`GROK_HOME`; the other tools use `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `COPILOT_HOME`, `XDG_DATA_HOME`, `PI_CODING_AGENT_DIR`, or `ZDOTDIR`)
-- `~/.gitconfig` is copied in (9p cannot mount single files)
+- `~/.gitconfig` is copied into the read-only environment share
 - Host system and user packages -> `/host-sw`, `/host-user-sw` (read-only, NixOS hosts only)
 - Any directories added via `--mount` / `--ro-mount`
 
@@ -179,7 +203,7 @@ All other host paths are invisible to the guest. Changes outside mounted directo
 
 On NixOS hosts, system packages (`/run/current-system/sw`) and user packages (`/etc/profiles/per-user/$USER`) are automatically mounted and added to PATH, so tools like `jj`, `ripgrep`, etc. are available without hardcoding them in the guest.
 
-**Processes.** The agent runs inside a full QEMU virtual machine - separate kernel, separate PID namespace. There is no shared process space with the host.
+**Processes.** The agent runs inside a Linux virtual machine with a separate kernel and process space. Linux uses QEMU/KVM and macOS uses Virtualization.framework.
 
 **Environment variables.** Only these are forwarded to the guest:
 
@@ -237,18 +261,18 @@ Default allowed domains per tool:
 |  writeShellApplication (mkRunner.nix)          |
 |    - parses CLI args                           |
 |    - writes env vars + tool args to tmpdir     |
-|    - sets up 9p virtfs mounts                  |
+|    - defines explicit host directory shares   |
 |    - optionally creates store disk image       |
-|    - launches qemu-system-*                    |
+|    - launches QEMU/KVM or VZ                   |
 +------------------+-----------------------------+
-                   | QEMU (direct kernel boot)
+                   | direct kernel boot
 +-- Guest (NixOS) -+-----------------------------+
-|  /nix/store <- overlay (9p lower + disk/tmpfs) |
+|  /nix/store <- overlay (shared lower + backing)|
 |  /nix/var   <- bind from disk/tmpfs backing    |
-|  /workspace <- 9p read-write                   |
+|  /workspace <- explicit read-write share       |
 |                                                |
 |  systemd                                       |
-|    -> llmjail-mounts: mount 9p shares          |
+|    -> llmjail-mounts: mount host shares        |
 |    -> llmjail-net-filter: dnsmasq + nftables   |
 |    -> llmjail-tool: exec the tool binary       |
 |                                                |
@@ -256,7 +280,18 @@ Default allowed domains per tool:
 +------------------------------------------------+
 ```
 
-No persistent disk images are involved. The guest kernel and initrd are built by NixOS and passed to QEMU via `-kernel` / `-initrd`. The host Nix store is shared read-only over 9p and used directly as the lower layer of a `/nix/store` overlay. `/nix/var` is bind-mounted from the same backing volume so build artifacts (`/nix/var/nix/builds/`) land on disk rather than the root tmpfs. When `--store-disk` is used, a sparse ext4 image backs both; otherwise a tmpfs is used. The image is cleaned up automatically when the VM exits.
+The guest kernel and initrd are built by NixOS and booted directly. Linux uses
+QEMU with KVM and 9p shares. Apple Silicon uses a small ad-hoc signed
+Virtualization.framework launcher and VirtioFS shares. Read-only shares are
+marked read-only by the host VZ configuration, not merely by the guest mount.
+`/nix/store` is the lower layer of an overlay whose writable backing is tmpfs or
+an explicit sparse ext4 `--store-disk`. The disk is removed when the VM exits.
+
+The trust boundary is narrow. The guest, agent, mutable workspace, and any
+supervisor traffic are untrusted. The host runner, VM process, and any optional
+supervisor listener are trusted. The guest can use only the directories and
+host interfaces selected at launch. This is authority containment, not a claim
+that an agent cannot do dangerous work inside its mounted workspace.
 
 ## Overriding tool packages
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "llm-jail - QEMU MicroVM sandbox for coding agents";
+  description = "llm-jail - microVM sandbox for coding agents";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -15,29 +15,40 @@
 
   outputs = { self, nixpkgs, nixpkgs-rolling, claude-code-nix, codex-cli-nix, llm-agents, autolith, nix-omp, ... }@inputs:
     let
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
       tools = import ./tools.nix;
 
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems f;
-      toolsForSystem = system:
-        nixpkgs.lib.filterAttrs
-          (_: def: builtins.elem system (def.systems or supportedSystems))
-          tools;
-
-      mkTool = system: toolName: toolDef:
+      guestSystemFor = hostSystem:
+        if hostSystem == "aarch64-darwin" then "aarch64-linux" else hostSystem;
+      autolithPackageFor = system:
+        nixpkgs.lib.attrByPath [ "packages" system "default" ] null autolith;
+      toolsForSystem = hostSystem:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          guestSystem = guestSystemFor hostSystem;
+        in
+          nixpkgs.lib.filterAttrs
+            (name: def:
+              builtins.elem guestSystem (def.systems or supportedSystems)
+              && (name != "autolith" || autolithPackageFor guestSystem != null)
+              && (hostSystem != "aarch64-darwin" || builtins.elem name [ "claude" "autolith" "shell" ]))
+            tools;
+
+      mkTool = hostSystem: toolName: toolDef:
+        let
+          guestSystem = guestSystemFor hostSystem;
+          pkgs = nixpkgs.legacyPackages.${hostSystem};
           # Default tool packages - overridable via `.override { claude-code = ...; }`
           # on the resulting runner derivation. Consumers can swap any of these
           # without forking the flake.
           defaultArgs = {
-            claude-code = claude-code-nix.packages.${system}.default;
-            codex-cli = codex-cli-nix.packages.${system}.default;
-            copilot-cli = llm-agents.packages.${system}.copilot-cli;
-            opencode = llm-agents.packages.${system}.opencode;
-            autolith = autolith.packages.${system}.default;
-            pi-coding-agent = llm-agents.packages.${system}.pi;
-            omp = nix-omp.packages.${system}.default;
+            claude-code = claude-code-nix.packages.${guestSystem}.default;
+            codex-cli = codex-cli-nix.packages.${guestSystem}.default;
+            copilot-cli = llm-agents.packages.${guestSystem}.copilot-cli;
+            opencode = llm-agents.packages.${guestSystem}.opencode;
+            autolith = autolithPackageFor guestSystem;
+            pi-coding-agent = llm-agents.packages.${guestSystem}.pi;
+            omp = nix-omp.packages.${guestSystem}.default;
           };
         in
         pkgs.lib.makeOverridable (
@@ -52,8 +63,9 @@
           }:
           let
             guest = nixpkgs.lib.nixosSystem {
-              inherit system;
+              system = guestSystem;
               specialArgs = {
+                hostBackend = if pkgs.stdenv.hostPlatform.isDarwin then "vz" else "qemu";
                 inherit
                   nixpkgs
                   nixpkgs-rolling
@@ -72,7 +84,7 @@
               ];
             };
           in import ./lib/mkRunner.nix {
-            inherit pkgs guest;
+            inherit pkgs guest guestSystem;
             name = toolName;
             toolDefaults = toolDef.defaults;
           }
@@ -91,20 +103,47 @@
       );
 
       checks = forAllSystems (system:
-        import ./tests {
-          inherit nixpkgs nixpkgs-rolling;
+        let
           pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;
           };
-          claude-code = claude-code-nix.packages.${system}.default;
-          codex-cli = codex-cli-nix.packages.${system}.default;
-          copilot-cli = llm-agents.packages.${system}.copilot-cli;
-          opencode = llm-agents.packages.${system}.opencode;
-          autolith = autolith.packages.${system}.default;
-          pi-coding-agent = llm-agents.packages.${system}.pi;
-          omp = nix-omp.packages.${system}.default;
-        }
+          darwinDnsSelectorCheck = pkgs.runCommand "llmjail-darwin-dns-selector" { } ''
+            selected=$(${pkgs.gawk}/bin/awk \
+              -f ${./lib/select-darwin-dns.awk} \
+              ${./tests/fixtures/scutil-dns-tailscale.txt})
+            test "$selected" = "192.0.2.53"
+
+            selected=$(${pkgs.gawk}/bin/awk \
+              -f ${./lib/select-darwin-dns.awk} \
+              ${./tests/fixtures/scutil-dns-no-ordinary-ipv4.txt})
+            test -z "$selected"
+
+            touch "$out"
+          '';
+        in {
+          darwin-dns-selector = darwinDnsSelectorCheck;
+        } // (
+          if pkgs.stdenv.hostPlatform.isDarwin then
+            {
+              claude-runner = self.packages.${system}.claude;
+              shell-runner = self.packages.${system}.shell;
+            }
+            // nixpkgs.lib.optionalAttrs (autolithPackageFor (guestSystemFor system) != null) {
+              autolith-runner = self.packages.${system}.autolith;
+            }
+          else
+            import ./tests {
+              inherit nixpkgs nixpkgs-rolling pkgs;
+              claude-code = claude-code-nix.packages.${system}.default;
+              codex-cli = codex-cli-nix.packages.${system}.default;
+              copilot-cli = llm-agents.packages.${system}.copilot-cli;
+              opencode = llm-agents.packages.${system}.opencode;
+              autolith = autolithPackageFor system;
+              pi-coding-agent = llm-agents.packages.${system}.pi;
+              omp = nix-omp.packages.${system}.default;
+            }
+        )
       );
     };
 }

--- a/guests/common.nix
+++ b/guests/common.nix
@@ -1,5 +1,13 @@
-{ config, lib, pkgs, nixpkgs-rolling, ... }:
+{ config, lib, pkgs, hostBackend, nixpkgs-rolling, ... }:
 
+let
+  useVz = hostBackend == "vz";
+  shareFileSystem = if useVz then "virtiofs" else "9p";
+  shareOptions =
+    if useVz
+    then [ "ro" ]
+    else [ "trans=virtio" "version=9p2000.L" "cache=loose" "msize=1048576" "ro" ];
+in
 {
   options.llmjail = {
     toolBinary = lib.mkOption {
@@ -17,15 +25,18 @@
     # Switch to systemd-initrd (default in 26.11). Required because we use
     # boot.initrd.systemd.services below to set up the /nix/store overlay.
     boot.initrd.systemd.enable = true;
-    boot.kernelParams = [ "console=ttyS1" ];
+    boot.kernelParams = [
+      (if useVz then "console=hvc0"
+       else if pkgs.stdenv.hostPlatform.isAarch64 then "console=ttyAMA0"
+       else "console=ttyS1")
+    ];
     boot.initrd.availableKernelModules = [
-      "9p"
-      "9pnet_virtio"
       "virtio_pci"
       "virtio_blk"
       "virtio_net"
       "virtio_rng"
-    ];
+    ] ++ lib.optionals useVz [ "virtiofs" ]
+      ++ lib.optionals (!useVz) [ "9p" "9pnet_virtio" ];
     # Force-load overlay in initrd: availableKernelModules only allows
     # autoload, but the systemd-initrd path doesn't always trigger it for
     # `mount -t overlay`, so make it explicit.
@@ -83,9 +94,44 @@
           /sysroot/.nix-backing/store-work \
           /sysroot/.nix-backing/var
 
+        ${lib.optionalString useVz ''
+          # The host selected only regular, zero-byte, mode-0600 Nix lock
+          # sidecars. Create OverlayFS whiteouts directly in the private upper
+          # layer because VirtioFS denies guest metadata access to the lower
+          # files themselves.
+          if [ -s /sysroot/llmjail-env/store-lock-sidecars ]; then
+            while IFS= read -r -d "" lock; do
+              case "$lock" in
+                */*|""|.|..)
+                  echo "Invalid host-store lock basename: $lock" >&2
+                  exit 1
+                  ;;
+                *.lock)
+                  ${pkgs.coreutils}/bin/mknod \
+                    "/sysroot/.nix-backing/store-upper/$lock" c 0 0
+                  ;;
+                *)
+                  echo "Invalid host-store lock basename: $lock" >&2
+                  exit 1
+                  ;;
+              esac
+            done < /sysroot/llmjail-env/store-lock-sidecars
+          fi
+        ''}
+
         mkdir -p /sysroot/nix/store
         mount -t overlay overlay /sysroot/nix/store \
           -o "lowerdir=/sysroot/.nix-lower/store,upperdir=/sysroot/.nix-backing/store-upper,workdir=/sysroot/.nix-backing/store-work"
+
+        ${lib.optionalString (!useVz) ''
+          # QEMU's 9p mapping lets the guest inspect the host lock metadata,
+          # so select and whiteout the exact sidecar shape through the overlay.
+          find /sysroot/.nix-lower/store \
+            -maxdepth 1 -type f -name '*.lock' -size 0 -perm 0600 -print |
+            while IFS= read -r lock; do
+              rm -f "/sysroot/nix/store/''${lock##*/}"
+            done
+        ''}
 
         mkdir -p /sysroot/nix/var
         mount --bind /sysroot/.nix-backing/var /sysroot/nix/var
@@ -104,8 +150,8 @@
     # crippling metadata-heavy tool I/O on large workspaces.
     fileSystems."/.nix-lower/store" = {
       device = "nix-store";
-      fsType = "9p";
-      options = [ "trans=virtio" "version=9p2000.L" "cache=loose" "msize=1048576" "ro" ];
+      fsType = shareFileSystem;
+      options = shareOptions;
       neededForBoot = true;
     };
 
@@ -120,13 +166,13 @@
     # take seconds.
     fileSystems."/llmjail-env" = {
       device = "envfs";
-      fsType = "9p";
-      options = [ "trans=virtio" "version=9p2000.L" "cache=loose" "msize=1048576" "ro" ];
+      fsType = shareFileSystem;
+      options = shareOptions;
       neededForBoot = true;
     };
 
     networking.useDHCP = false;
-    networking.nameservers = [ "10.0.2.3" ];
+    networking.nameservers = lib.optionals (!useVz) [ "10.0.2.3" ];
     networking.firewall.enable = false;
 
     # nixos-26.05 + systemd-networkd auto-enables resolved, which inserts
@@ -147,6 +193,34 @@
       wait-online.enable = true;
     };
 
+    systemd.services.llmjail-vz-resolver = lib.mkIf useVz {
+      description = "Install the VZ NAT resolver from DHCP";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      before = [ "llmjail-net-filter.service" "llmjail-tool.service" ];
+      serviceConfig.Type = "oneshot";
+      script = ''
+        set -eu
+        DNS_SERVER=""
+        if [ -s /llmjail-env/host-dns ]; then
+          IFS= read -r DNS_SERVER < /llmjail-env/host-dns
+        else
+          for lease in /run/systemd/netif/leases/*; do
+            [ -f "$lease" ] || continue
+            DNS_SERVER=$(${pkgs.gnused}/bin/sed -n 's/^DNS=//p' "$lease" \
+              | ${pkgs.gawk}/bin/awk '{ print $1; exit }')
+            [ -n "$DNS_SERVER" ] && break
+          done
+        fi
+        if [ -z "$DNS_SERVER" ]; then
+          echo "Could not determine the VZ NAT DNS server." >&2
+          exit 1
+        fi
+        echo "nameserver $DNS_SERVER" > /etc/resolv.conf
+      '';
+    };
+
     users.users.user = {
       isNormalUser = true;
       uid = 1000;
@@ -154,6 +228,11 @@
       shell = pkgs.bash;
       extraGroups = [ "tty" "dialout" "systemd-journal" ];
     };
+
+    services.udev.extraRules = ''
+      KERNEL=="vport*", SUBSYSTEM=="virtio-ports", ATTR{name}=="llmjail.supervisor", OWNER:="root", GROUP:="dialout", MODE:="0660"
+      ${lib.optionalString useVz ''KERNEL=="hvc1", OWNER:="root", GROUP:="dialout", MODE:="0660"''}
+    '';
 
     users.mutableUsers = true;
     systemd.services.llmjail-set-user-uid = {
@@ -166,7 +245,9 @@
             llmjail.user_uid=*) USER_UID="''${arg#llmjail.user_uid=}" ;;
           esac
         done
-        if [[ -n "$USER_UID" && "$USER_UID" -ge 1000 ]] && ! ${pkgs.getent}/bin/getent passwd "$USER_UID"; then
+        # Darwin login UIDs commonly start at 501. Avoid only the system UID
+        # range below 500, and retain the collision check before changing it.
+        if [[ -n "$USER_UID" && "$USER_UID" -ge 500 ]] && ! ${pkgs.getent}/bin/getent passwd "$USER_UID"; then
           ${pkgs.shadow}/bin/usermod -u "$USER_UID" user
         fi
       '';
@@ -176,9 +257,9 @@
     };
 
     # Parses kernel cmdline for llmjail.mounts=tag0:/path:rw,tag1:/path:ro,...
-    # and mounts each entry via 9p.
+    # and mounts each entry through the selected host sharing backend.
     systemd.services.llmjail-mounts = {
-      description = "Mount llmjail 9p shares from kernel cmdline";
+      description = "Mount llmjail host shares from kernel cmdline";
       wantedBy = [ "multi-user.target" ];
       before = [ "llmjail-tool.service" ];
       after = [ "local-fs.target" ];
@@ -208,13 +289,25 @@
           echo "Mounting $tag -> $mpath ($mode)"
           ${pkgs.coreutils}/bin/mkdir -p "$mpath"
 
-          OPTS="trans=virtio,version=9p2000.L,cache=mmap,msize=1048576"
-          if [ "$mode" = "ro" ]; then
-            OPTS="$OPTS,ro"
-          elif [ "$mode" = "ro-nocache" ]; then
-            OPTS="trans=virtio,version=9p2000.L,cache=none,msize=1048576,ro"
-          fi
-          ${pkgs.util-linux}/bin/mount -t 9p "$tag" "$mpath" -o "$OPTS"
+          ${if useVz then ''
+            OPTS=""
+            if [ "$mode" = "ro" ] || [ "$mode" = "ro-nocache" ]; then
+              OPTS="ro"
+            fi
+            if [ -n "$OPTS" ]; then
+              ${pkgs.util-linux}/bin/mount -t virtiofs "$tag" "$mpath" -o "$OPTS"
+            else
+              ${pkgs.util-linux}/bin/mount -t virtiofs "$tag" "$mpath"
+            fi
+          '' else ''
+            OPTS="trans=virtio,version=9p2000.L,cache=mmap,msize=1048576"
+            if [ "$mode" = "ro" ]; then
+              OPTS="$OPTS,ro"
+            elif [ "$mode" = "ro-nocache" ]; then
+              OPTS="trans=virtio,version=9p2000.L,cache=none,msize=1048576,ro"
+            fi
+            ${pkgs.util-linux}/bin/mount -t 9p "$tag" "$mpath" -o "$OPTS"
+          ''}
 
           # Fix ownership for paths under /home/user
           case "$mpath" in
@@ -309,12 +402,13 @@
     systemd.services.llmjail-net-filter = {
       description = "llmjail network filter (DNS whitelist + nftables)";
       wantedBy = [ "multi-user.target" ];
-      after = [ "llmjail-mounts.service" "network-online.target" ];
+      after = [ "llmjail-mounts.service" "network-online.target" ]
+        ++ lib.optionals useVz [ "llmjail-vz-resolver.service" ];
       wants = [ "network-online.target" ];
       before = [ "llmjail-tool.service" ];
       serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
+        Type = "notify";
+        NotifyAccess = "all";
       };
       script = ''
         set -euo pipefail
@@ -328,17 +422,50 @@
 
         if [ "$NET_FILTER" != "1" ]; then
           echo "Network filtering disabled."
+          ${pkgs.systemd}/bin/systemd-notify --ready
           exit 0
+        fi
+
+        ALLOWED_DOMAINS=/llmjail-env/allowed-domains
+        if [ -f /run/llmjail-allowed-domains ]; then
+          ALLOWED_DOMAINS=/run/llmjail-allowed-domains
+        fi
+
+        # Make restarts replace both dnsmasq and the firewall state before the
+        # tool starts.
+        if [ -s /run/dnsmasq-llmjail.pid ]; then
+          DNSMASQ_PID=$(cat /run/dnsmasq-llmjail.pid)
+          kill "$DNSMASQ_PID" 2>/dev/null || true
+          while kill -0 "$DNSMASQ_PID" 2>/dev/null; do
+            sleep 0.05
+          done
+        fi
+        ${pkgs.nftables}/bin/nft delete table inet llmjail_filter 2>/dev/null || true
+
+        UPSTREAM_DNS=""
+        if [ -s /llmjail-env/host-dns ]; then
+          IFS= read -r UPSTREAM_DNS < /llmjail-env/host-dns
+        else
+          for lease in /run/systemd/netif/leases/*; do
+            [ -f "$lease" ] || continue
+            UPSTREAM_DNS=$(${pkgs.gnused}/bin/sed -n 's/^DNS=//p' "$lease" \
+              | ${pkgs.gawk}/bin/awk '{ print $1; exit }')
+            [ -n "$UPSTREAM_DNS" ] && break
+          done
+        fi
+        if [ -z "$UPSTREAM_DNS" ]; then
+          echo "Could not determine the VM NAT DNS server." >&2
+          exit 1
         fi
 
         # Must run before dnsmasq so allowed_ips set exists when
         # dnsmasq populates it on first DNS resolution.
-        ${pkgs.nftables}/bin/nft -f - <<'NFTEOF'
+        ${pkgs.nftables}/bin/nft -f - <<NFTEOF
         table inet llmjail_filter {
           # Populated by dnsmasq --nftset on each successful DNS resolution.
           # HTTP/HTTPS is only allowed to IPs that appear here, blocking
           # direct hardcoded-IP connections that bypass DNS filtering.
-          # Plain set (no `flags interval`) so dnsmasq can add individual
+          # Plain set without interval flags so dnsmasq can add individual
           # /32 entries - interval sets reject single addresses in some
           # nft/dnsmasq combos.
           set allowed_ips {
@@ -354,8 +481,8 @@
 
             udp dport { 67, 68 } accept
 
-            ip daddr 10.0.2.3 udp dport 53 meta skuid root accept
-            ip daddr 10.0.2.3 tcp dport 53 meta skuid root accept
+            ip daddr $UPSTREAM_DNS udp dport 53 meta skuid root accept
+            ip daddr $UPSTREAM_DNS tcp dport 53 meta skuid root accept
 
             ip daddr @allowed_ips tcp dport { 80, 443 } accept
 
@@ -371,14 +498,14 @@
           echo "listen-address=127.0.0.1"
           echo "bind-interfaces"
 
-          # Forward allowed domains to QEMU's DNS; populate nftables set
+          # Forward allowed domains to the VM NAT DNS server; populate nftables set
           # on each successful resolution so the IP becomes reachable.
-          if [ -f /llmjail-env/allowed-domains ]; then
+          if [ -f "$ALLOWED_DOMAINS" ]; then
             while IFS= read -r domain || [ -n "$domain" ]; do
               [ -z "$domain" ] && continue
-              echo "server=/$domain/10.0.2.3"
+              echo "server=/$domain/$UPSTREAM_DNS"
               echo "nftset=/$domain/4#inet#llmjail_filter#allowed_ips"
-            done < /llmjail-env/allowed-domains
+            done < "$ALLOWED_DOMAINS"
           fi
 
           # No default upstream - unmatched queries get REFUSED
@@ -393,12 +520,28 @@
           --conf-file="$DNSMASQ_CONF" \
           --pid-file=/run/dnsmasq-llmjail.pid \
           --user=root \
+          --keep-in-foreground \
           --log-queries=extra \
-          --log-facility=-
+          --log-facility=- &
+        DNSMASQ_PID=$!
+
+        for _ in $(${pkgs.coreutils}/bin/seq 1 100); do
+          [ -s /run/dnsmasq-llmjail.pid ] && break
+          kill -0 "$DNSMASQ_PID" 2>/dev/null || wait "$DNSMASQ_PID"
+          sleep 0.01
+        done
+        if [ ! -s /run/dnsmasq-llmjail.pid ]; then
+          echo "dnsmasq did not become ready." >&2
+          kill "$DNSMASQ_PID" 2>/dev/null || true
+          wait "$DNSMASQ_PID" 2>/dev/null || true
+          exit 1
+        fi
 
         echo "nameserver 127.0.0.1" > /etc/resolv.conf
 
-        echo "Network filtering enabled with $(${pkgs.coreutils}/bin/wc -l < /llmjail-env/allowed-domains) allowed domain(s)."
+        echo "Network filtering enabled with $(${pkgs.coreutils}/bin/wc -l < "$ALLOWED_DOMAINS") allowed domain(s)."
+        ${pkgs.systemd}/bin/systemd-notify --ready
+        wait "$DNSMASQ_PID"
       '';
     };
 
@@ -406,7 +549,7 @@
     # core handles the ioctl (driver-independent), so it delivers SIGWINCH to
     # hvc0's foreground pgrp just as it did for ttyS0.
     systemd.services.llmjail-winsize = {
-      description = "Apply terminal size updates from host via virtio-serial";
+      description = "Apply terminal size updates from host";
       wantedBy = [ "multi-user.target" ];
       before = [ "llmjail-tool.service" ];
       after = [ "llmjail-mounts.service" ];
@@ -420,27 +563,50 @@
       };
       script = ''
         set -eu
-        while [ ! -e /dev/virtio-ports/llmjail.winsize ]; do
-          sleep 0.1
-        done
         PREV=""
-        while IFS=' ' read -r COLS ROWS; do
+        {
+          ${if useVz then ''
+          WINSIZE_DEVICE=""
+          for arg in $(cat /proc/cmdline); do
+            case "$arg" in
+              llmjail.winsize_device=*) WINSIZE_DEVICE="''${arg#llmjail.winsize_device=}" ;;
+            esac
+          done
+          if [ -z "$WINSIZE_DEVICE" ]; then
+            echo "No VZ winsize device was configured." >&2
+            exit 1
+          fi
+          while [ ! -e "$WINSIZE_DEVICE" ]; do
+            sleep 0.1
+          done
+          ${pkgs.coreutils}/bin/cat "$WINSIZE_DEVICE"
+        '' else ''
+          while [ ! -e /dev/virtio-ports/llmjail.winsize ]; do
+            sleep 0.1
+          done
+          ${pkgs.coreutils}/bin/cat /dev/virtio-ports/llmjail.winsize
+          ''}
+        } | while IFS=' ' read -r COLS ROWS; do
           [ -n "$COLS" ] && [ -n "$ROWS" ] || continue
           [ "$COLS $ROWS" = "$PREV" ] && continue
           PREV="$COLS $ROWS"
           ${pkgs.coreutils}/bin/stty cols "$COLS" rows "$ROWS" < /dev/hvc0 2>/dev/null || true
-        done < /dev/virtio-ports/llmjail.winsize
+        done
       '';
     };
 
-    # Register the host store's paths in the guest nix db before the
-    # nix-daemon starts. Preferred source is a snapshot of the host's
+    # Initialize the guest nix db before the nix-daemon starts. Reuse an
+    # existing database when a persistent store disk is attached so paths
+    # realized by an earlier launch remain registered. Load the current
+    # toplevel closure into that database in case the runner was upgraded.
+    #
+    # A new backing store is seeded from a snapshot of the host's
     # /nix/var/nix/db/db.sqlite (llmjail.nix_db_snapshot, taken by the
-    # runner via `sqlite3 VACUUM INTO` and shipped through the envfs share):
-    # installing the file takes milliseconds, vs minutes for --load-db of
-    # a big store. Falls back to the toplevel closure registration dump
-    # (llmjail.nix_db_dump) when no snapshot is available. Mostly copied
-    # from nixpkgs/nixos/modules/virtualisation/qemu-vm.nix.
+    # runner via `sqlite3 VACUUM INTO` and shipped through the envfs share).
+    # Installing the file takes milliseconds, versus minutes for --load-db
+    # of a big store. It falls back to the toplevel closure registration
+    # dump (llmjail.nix_db_dump) when no snapshot is available. Mostly
+    # copied from nixpkgs/nixos/modules/virtualisation/qemu-vm.nix.
     systemd.services.register-nix-paths = {
       unitConfig.DefaultDependencies = false;
       wantedBy = [ "sysinit.target" ];
@@ -468,13 +634,19 @@
           esac
         done
 
-        if [[ -n "$NIX_DB_SNAPSHOT" ]] && [[ -s "$NIX_DB_SNAPSHOT" ]]; then
+        NIX_DB=/nix/var/nix/db/db.sqlite
+        ${pkgs.coreutils}/bin/mkdir -p /nix/var/nix/db
+
+        if [[ -s "$NIX_DB" ]]; then
+          echo "Reusing persistent guest nix db"
+          if [[ -n "$NIX_DB_DUMP" ]]; then
+            echo "Registering current closure nix db dump ($NIX_DB_DUMP)"
+            ${lib.getExe' config.nix.package "nix-store"} --load-db < "$NIX_DB_DUMP"
+          fi
+        elif [[ -n "$NIX_DB_SNAPSHOT" ]] && [[ -s "$NIX_DB_SNAPSHOT" ]]; then
           echo "Installing host nix db snapshot ($NIX_DB_SNAPSHOT)"
-          ${pkgs.coreutils}/bin/mkdir -p /nix/var/nix/db
-          # Drop leftover WAL state from a previous boot on a persistent
-          # store disk; the snapshot is a clean standalone db.
           ${pkgs.coreutils}/bin/rm -f /nix/var/nix/db/db.sqlite-wal /nix/var/nix/db/db.sqlite-shm
-          ${pkgs.coreutils}/bin/install -m 0644 "$NIX_DB_SNAPSHOT" /nix/var/nix/db/db.sqlite
+          ${pkgs.coreutils}/bin/install -m 0644 "$NIX_DB_SNAPSHOT" "$NIX_DB"
         elif [[ -n "$NIX_DB_DUMP" ]]; then
           echo "Loading closure nix db dump ($NIX_DB_DUMP)"
           ${lib.getExe' config.nix.package "nix-store"} --load-db < "$NIX_DB_DUMP"
@@ -482,6 +654,7 @@
           echo "<4> No Nix db snapshot or dump specified, not initializing Nix db"
           exit 1
         fi
+
       '';
     };
 
@@ -565,6 +738,7 @@
 
     systemd.services."serial-getty@ttyS0".enable = false;
     systemd.services."serial-getty@ttyS1".enable = false;
+    systemd.services."serial-getty@ttyAMA0".enable = false;
     systemd.services."serial-getty@hvc0".enable = false;
     systemd.services."getty@tty1".enable = false;
     systemd.services."getty@hvc0".enable = false;

--- a/guests/shell.nix
+++ b/guests/shell.nix
@@ -5,7 +5,8 @@
 
   llmjail.toolBinary = pkgs.writeShellScript "shell-launcher" ''
     # Honor host's $SHELL (resolved through symlinks by the runner so the
-    # value points at /nix/store, which the guest reaches via 9p). Fall back
+    # value points at /nix/store, which the guest reaches through its read-only
+    # store share). Fall back
     # to whatever shell is reachable via PATH (covers /host-user-sw and
     # /host-sw on NixOS hosts), then to the guest's bash on non-NixOS hosts.
     if [ -n "''${SHELL:-}" ] && [ -x "$SHELL" ]; then

--- a/lib/mkRunner.nix
+++ b/lib/mkRunner.nix
@@ -1,6 +1,7 @@
 { pkgs
 , name
 , guest
+, guestSystem
 , toolDefaults
 ,
 }:
@@ -8,22 +9,22 @@
 let
   toplevel = guest.config.system.build.toplevel;
   toplevelDbDump = pkgs.closureInfo { rootPaths = [ toplevel ]; };
-  qemuPkg = pkgs.qemu_kvm;
-  arch = if pkgs.stdenv.hostPlatform.isx86_64 then "x86_64" else "aarch64";
+  hostIsDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+  guestIsAarch64 = guestSystem == "aarch64-linux";
+  arch = if guestIsAarch64 then "aarch64" else "x86_64";
+  vzRunner = if hostIsDarwin then import ./vz-runner { inherit pkgs; } else null;
 in
 pkgs.writeShellApplication {
   name = "llm-jail-${name}";
   runtimeInputs = [
-    qemuPkg
     pkgs.coreutils
-    pkgs.util-linux
     pkgs.nix
     pkgs.devenv
     pkgs.e2fsprogs
-    pkgs.pv
     pkgs.socat
     pkgs.sqlite
-  ];
+  ] ++ pkgs.lib.optional hostIsDarwin vzRunner
+    ++ pkgs.lib.optionals (!hostIsDarwin) [ pkgs.qemu_kvm pkgs.pv ];
   text = ''
     set -euo pipefail
 
@@ -40,6 +41,7 @@ pkgs.writeShellApplication {
     EXTRA_DOMAINS=()
     EXTRA_MOUNTS=()
     MASK_PATTERNS=()
+    SUPERVISOR_SOCKET=""
     TOOL_ARGS=()
 
     PROFILE="''${LLMJAIL_PROFILE:-default}"
@@ -74,6 +76,9 @@ pkgs.writeShellApplication {
                             Matched paths appear empty and read-only; the name stays
                             visible, only the contents are hidden.
                             Applied at boot only; new matches post-boot are not masked.
+      --supervisor-socket ABSOLUTE_PATH
+                            Connect a private guest serial device to an
+                            existing host Unix socket listener
       --nix-env             Capture nix develop environment from workspace flake
       --devenv              Capture devenv.sh shell environment from workspace
       --store-disk SIZE     Create a disk-backed /nix overlay (SIZE in GB)
@@ -83,7 +88,7 @@ pkgs.writeShellApplication {
       --vcpu COUNT          vCPUs (default: ${toString toolDefaults.vcpu})
       -h, --help            Show this help
 
-    Press Ctrl-a x to force-quit QEMU.
+    ${if hostIsDarwin then "Press Ctrl-c to stop the VM." else "Press Ctrl-a x to force-quit QEMU."}
     USAGE
       exit 0
     }
@@ -122,6 +127,8 @@ pkgs.writeShellApplication {
         --allow-domain)  EXTRA_DOMAINS+=("$2"); shift 2 ;;
         --no-net-filter) NET_FILTER=0; shift ;;
         --mask)        MASK_PATTERNS+=("$2"); shift 2 ;;
+        --supervisor-socket)
+                       SUPERVISOR_SOCKET="$2"; shift 2 ;;
         --store-disk)  STORE_DISK="$2"; shift 2 ;;
         --mem)         MEM="$2"; shift 2 ;;
         --vcpu)        VCPU="$2"; shift 2 ;;
@@ -137,7 +144,8 @@ pkgs.writeShellApplication {
     if [ -z "$STATE_DIR" ]; then
       STATE_DIR="''${XDG_CONFIG_HOME:-$HOME/.config}/llm-jail"
     fi
-    STATE_DIR="$STATE_DIR/${name}/$PROFILE"
+    STATE_ROOT="$STATE_DIR"
+    STATE_DIR="$STATE_ROOT/${name}/$PROFILE"
 
     if [ ! -d "$LLMJAIL_TMPDIR" ]; then
       echo "ERROR: tmpdir '$LLMJAIL_TMPDIR' does not exist" >&2
@@ -163,12 +171,38 @@ pkgs.writeShellApplication {
     }
 
     validate_path "$LLMJAIL_TMPDIR" "tmpdir"
+    if [ -n "$SUPERVISOR_SOCKET" ]; then
+      if [[ "$SUPERVISOR_SOCKET" != /* ]]; then
+        echo "ERROR: supervisor socket path must be absolute: $SUPERVISOR_SOCKET" >&2
+        exit 1
+      fi
+      if [[ "$SUPERVISOR_SOCKET" == *,* ]]; then
+        echo "ERROR: supervisor socket path must not contain commas: $SUPERVISOR_SOCKET" >&2
+        exit 1
+      fi
+      if [ ! -S "$SUPERVISOR_SOCKET" ]; then
+        echo "ERROR: supervisor socket is not an existing Unix socket: $SUPERVISOR_SOCKET" >&2
+        exit 1
+      fi
+    fi
     RUNDIR=$(mktemp -d --tmpdir="$LLMJAIL_TMPDIR")
 
     cleanup_rundir() {
       [ -d "$RUNDIR" ] && rm -rf "$RUNDIR"
     }
     CLEANUP_FUNCS+=(cleanup_rundir)
+
+    SUPERVISOR_VM_ARGS=()
+    if [ -n "$SUPERVISOR_SOCKET" ]; then
+      ${if hostIsDarwin then ''
+        SUPERVISOR_VM_ARGS=(--supervisor-socket "$SUPERVISOR_SOCKET")
+      '' else ''
+        SUPERVISOR_VM_ARGS=(
+          -chardev "socket,id=supervisor,path=$SUPERVISOR_SOCKET,server=off"
+          -device "virtserialport,chardev=supervisor,name=llmjail.supervisor"
+        )
+      ''}
+    fi
 
     # TODO: QEMU has a pending patch series (v6, "console: add
     # TIOCSWINSZ support") that adds native SIGWINCH->virtconsole
@@ -185,7 +219,9 @@ pkgs.writeShellApplication {
     # exits, so a dedicated subshell owns the SIGWINCH trap and parks in
     # `sleep & wait` - wait's trap-interrupt semantics fire the trap
     # promptly on each resize.
-    WINSIZE_SOCK="$RUNDIR/winsize.sock"
+    ${pkgs.lib.optionalString (!hostIsDarwin) ''
+      WINSIZE_SOCK="$RUNDIR/winsize.sock"
+    ''}
     WINSIZE_FIFO="$RUNDIR/winsize.fifo"
     mkfifo "$WINSIZE_FIFO"
     # Hold the FIFO open RDWR on fd 3 so trap writes never block on
@@ -242,15 +278,17 @@ pkgs.writeShellApplication {
         fi
       done
 
-      # Forward host shell (resolved through symlinks so the /nix/store path
-      # is exposed, which the guest can reach via the 9p store mount even
-      # though /run/current-system/sw is remapped to /host-sw).
-      if [ -n "''${SHELL:-}" ]; then
-        RESOLVED_SHELL=$(readlink -f "$SHELL" 2>/dev/null || true)
-        if [ -n "$RESOLVED_SHELL" ]; then
-          echo "SHELL=\"$RESOLVED_SHELL\""
+      ${pkgs.lib.optionalString (!hostIsDarwin) ''
+        # Forward a Linux host shell resolved into /nix/store. Darwin shell
+        # binaries cannot execute in the Linux guest, which already includes
+        # explicit bash and zsh packages.
+        if [ -n "''${SHELL:-}" ]; then
+          RESOLVED_SHELL=$(readlink -f "$SHELL" 2>/dev/null || true)
+          if [ -n "$RESOLVED_SHELL" ]; then
+            echo "SHELL=\"$RESOLVED_SHELL\""
+          fi
         fi
-      fi
+      ''}
 
       env | grep '^AWS_' || true
 
@@ -270,6 +308,9 @@ pkgs.writeShellApplication {
 
       echo "HOME=/home/user"
       echo "LLMJAIL_DANGEROUS=$DANGEROUS"
+      if [ -n "$SUPERVISOR_SOCKET" ]; then
+        echo "LLMJAIL_SUPERVISOR_DEVICE=${if hostIsDarwin then "/dev/hvc1" else "/dev/virtio-ports/llmjail.supervisor"}"
+      fi
       # Relocate the tool's state into the jail-private state mount
       echo "${toolDefaults.configEnvVar}=/home/user/${toolDefaults.configDirName}"
       echo "WORKSPACE_DIR=\"$WORKSPACE_DIR\""
@@ -304,10 +345,26 @@ pkgs.writeShellApplication {
         for d in "''${EXTRA_DOMAINS[@]+"''${EXTRA_DOMAINS[@]}"}"; do
           echo "$d"
         done
+      } | sort -u > "$RUNDIR/runtime-allowed-domains"
+
+      {
+        cat "$RUNDIR/runtime-allowed-domains"
+        ${builtins.concatStringsSep "\n    " (
+          map (d: "echo \"${d}\"") (toolDefaults.buildAllowedDomains or [ ])
+        )}
       } | sort -u > "$RUNDIR/allowed-domains"
     else
       : > "$RUNDIR/allowed-domains"
+      : > "$RUNDIR/runtime-allowed-domains"
     fi
+
+    ${pkgs.lib.optionalString hostIsDarwin ''
+      HOST_DNS=$(/usr/sbin/scutil --dns \
+        | ${pkgs.gawk}/bin/awk -f ${./select-darwin-dns.awk})
+      if [ -n "$HOST_DNS" ]; then
+        printf '%s\n' "$HOST_DNS" > "$RUNDIR/host-dns"
+      fi
+    ''}
 
     if [ "$NIX_ENV" = "1" ] && [ "$DEVENV" = "1" ]; then
       echo "ERROR: --nix-env and --devenv are mutually exclusive" >&2
@@ -381,7 +438,7 @@ pkgs.writeShellApplication {
 
     MOUNT_IDX=0
     MOUNT_CMDLINE=""
-    VIRTFS_ARGS=()
+    SHARE_ARGS=()
     MASK_ROOTS=()
 
     add_mount() {
@@ -389,11 +446,19 @@ pkgs.writeShellApplication {
       local tag="mount''${MOUNT_IDX}"
       MOUNT_IDX=$((MOUNT_IDX + 1))
 
-      local virtfs="local,path=$hostpath,security_model=none,mount_tag=$tag"
-      if [ "$mode" = "ro" ] || [ "$mode" = "ro-nocache" ]; then
-        virtfs="$virtfs,readonly=on"
-      fi
-      VIRTFS_ARGS+=("-virtfs" "$virtfs")
+      ${if hostIsDarwin then ''
+        local share_mode="rw"
+        if [ "$mode" = "ro" ] || [ "$mode" = "ro-nocache" ]; then
+          share_mode="ro"
+        fi
+        SHARE_ARGS+=("--share" "$tag:$hostpath:$share_mode")
+      '' else ''
+        local virtfs="local,path=$hostpath,security_model=none,mount_tag=$tag"
+        if [ "$mode" = "ro" ] || [ "$mode" = "ro-nocache" ]; then
+          virtfs="$virtfs,readonly=on"
+        fi
+        SHARE_ARGS+=("-virtfs" "$virtfs")
+      ''}
 
       if [ -n "$MOUNT_CMDLINE" ]; then
         MOUNT_CMDLINE="$MOUNT_CMDLINE,$tag:$guestpath:$mode"
@@ -414,12 +479,12 @@ pkgs.writeShellApplication {
     MASK_ROOTS+=("$WORKSPACE_DIR")
 
     validate_path "$STATE_DIR" "state directory"
-    # 9p refuses to share a non-existent path; first run starts empty and
+    # Host directory shares require an existing path; first run starts empty and
     # the tool goes through its login/onboarding flow inside the jail.
     mkdir -p "$STATE_DIR"
     add_mount "$STATE_DIR" "/home/user/${toolDefaults.configDirName}" "rw"
 
-    # Copy .gitconfig into the envfs share (9p can't mount single files)
+    # Copy .gitconfig into the environment share because shares are directories.
     if [ -f "$HOME/.gitconfig" ]; then
       cp "$HOME/.gitconfig" "$RUNDIR/.gitconfig"
     fi
@@ -444,17 +509,19 @@ pkgs.writeShellApplication {
       fi
     fi
 
-    # Mount host packages if available (NixOS host)
-    if [ -d /run/current-system/sw ]; then
-      add_mount "/run/current-system/sw" "/host-sw" "ro"
-    fi
+    ${pkgs.lib.optionalString (!hostIsDarwin) ''
+      # Mount host packages if available (NixOS host).
+      if [ -d /run/current-system/sw ]; then
+        add_mount "/run/current-system/sw" "/host-sw" "ro"
+      fi
 
-    # whoami from nixpkgs coreutils won't work on non-NixOS systems that have the user come from
-    # sssd and don't have nscd/nsncd enabled
-    USERNAME=$(whoami 2>/dev/null) || USERNAME="$USER"
-    if [ -n "$USERNAME" ] && [ -d "/etc/profiles/per-user/$USERNAME" ]; then
-      add_mount "/etc/profiles/per-user/$USERNAME" "/host-user-sw" "ro"
-    fi
+      # whoami from nixpkgs coreutils won't work on non-NixOS systems that
+      # have the user come from sssd and don't have nscd/nsncd enabled.
+      USERNAME=$(whoami 2>/dev/null) || USERNAME="$USER"
+      if [ -n "$USERNAME" ] && [ -d "/etc/profiles/per-user/$USERNAME" ]; then
+        add_mount "/etc/profiles/per-user/$USERNAME" "/host-user-sw" "ro"
+      fi
+    ''}
 
     for spec in "''${EXTRA_MOUNTS[@]+"''${EXTRA_MOUNTS[@]}"}"; do
       if [ -z "$spec" ]; then continue; fi
@@ -493,7 +560,7 @@ pkgs.writeShellApplication {
       : > "$RUNDIR/mask-roots"
     fi
 
-    KERNEL_PARAMS="$(cat ${toplevel}/kernel-params) init=${toplevel}/init console=ttyS1 llmjail.mounts=$MOUNT_CMDLINE"
+    KERNEL_PARAMS="$(cat ${toplevel}/kernel-params) init=${toplevel}/init llmjail.mounts=$MOUNT_CMDLINE"
 
     if [ "$STORE_DISK" -gt 0 ]; then
       KERNEL_PARAMS="$KERNEL_PARAMS llmjail.store_disk=1"
@@ -512,30 +579,77 @@ pkgs.writeShellApplication {
     fi
 
     KERNEL_PARAMS="$KERNEL_PARAMS llmjail.nix_db_dump=${toplevelDbDump}/registration"
+    ${pkgs.lib.optionalString hostIsDarwin ''
+      WINSIZE_DEVICE=/dev/hvc1
+      if [ -n "$SUPERVISOR_SOCKET" ]; then
+        WINSIZE_DEVICE=/dev/hvc2
+      fi
+      KERNEL_PARAMS="$KERNEL_PARAMS llmjail.winsize_device=$WINSIZE_DEVICE"
+    ''}
 
     DISK_ARGS=()
     if [ "$STORE_DISK" -gt 0 ]; then
-      truncate -s "''${STORE_DISK}G" "$RUNDIR/store.img"
-      mkfs.ext4 -q "$RUNDIR/store.img"
-      DISK_ARGS+=("-drive" "file=$RUNDIR/store.img,format=raw,if=virtio,discard=on")
+      STORE_IMAGE="$RUNDIR/store.img"
+      truncate -s "''${STORE_DISK}G" "$STORE_IMAGE"
+      mkfs.ext4 -q "$STORE_IMAGE"
+      ${if hostIsDarwin then ''
+        DISK_ARGS+=(--disk "$STORE_IMAGE")
+      '' else ''
+        DISK_ARGS+=("-drive" "file=$STORE_IMAGE,format=raw,if=virtio,discard=on")
+      ''}
     fi
 
-    KVM_ARGS=()
-    if [ -w /dev/kvm ]; then
-      KVM_ARGS+=("-enable-kvm" "-cpu" "host")
-    else
-      echo "WARNING: /dev/kvm not available, falling back to emulation (slow)" >&2
-      KVM_ARGS+=("-cpu" "max")
-    fi
+    ${if hostIsDarwin then ''
+      # VirtioFS cannot expose metadata for host Nix lock sidecars that the
+      # host daemon owns with mode 0600. Select the exact sidecar shape after
+      # all host-side Nix work so the guest can hide those foreign lock names
+      # in its overlay.
+      ${pkgs.findutils}/bin/find /nix/store \
+        -maxdepth 1 \
+        -type f \
+        -name '*.lock' \
+        -size 0c \
+        -perm 0600 \
+        -printf '%f\0' \
+        > "$RUNDIR/store-lock-sidecars"
 
-    # socat itself retries the UNIX-CONNECT until QEMU binds the socket,
-    # so no polling loop is needed.
-    socat -u "PIPE:$WINSIZE_FIFO" "UNIX-CONNECT:$WINSIZE_SOCK,retry=100,interval=0.1" 2>/dev/null &
-    SOCAT_PID=$!
-    cleanup_socat() {
-      kill "$SOCAT_PID" 2>/dev/null
-    }
-    CLEANUP_FUNCS+=(cleanup_socat)
+      printf '%s\n' "$KERNEL_PARAMS" > "$RUNDIR/kernel-params"
+      llm-jail-vz \
+        --cpus "$VCPU" \
+        --memory "$MEM" \
+        --kernel ${toplevel}/kernel \
+        --initrd ${toplevel}/initrd \
+        --cmdline-file "$RUNDIR/kernel-params" \
+        --share "nix-store:/nix/store:ro" \
+        --share "envfs:$RUNDIR:ro" \
+        --winsize-input "$WINSIZE_FIFO" \
+        "''${SUPERVISOR_VM_ARGS[@]}" \
+        "''${SHARE_ARGS[@]}" \
+        "''${DISK_ARGS[@]}"
+    '' else ''
+      ACCEL_ARGS=()
+      if [ -w /dev/kvm ]; then
+        ACCEL_ARGS+=("-accel" "kvm" "-cpu" "host")
+      else
+        echo "WARNING: /dev/kvm not available, falling back to emulation (slow)" >&2
+        ACCEL_ARGS+=("-accel" "tcg" "-cpu" "max")
+      fi
+
+      MACHINE_ARGS=()
+      SERIAL_ARGS=()
+      ${if guestIsAarch64 then ''
+        MACHINE_ARGS+=("-machine" "virt")
+        SERIAL_ARGS+=("-serial" "file:$RUNDIR/kernel.log")
+      '' else ''
+        SERIAL_ARGS+=("-serial" "null" "-serial" "file:$RUNDIR/kernel.log")
+      ''}
+
+      socat -u "PIPE:$WINSIZE_FIFO" "UNIX-CONNECT:$WINSIZE_SOCK,retry=100,interval=0.1" 2>/dev/null &
+      SOCAT_PID=$!
+      cleanup_socat() {
+        kill "$SOCAT_PID" 2>/dev/null
+      }
+      CLEANUP_FUNCS+=(cleanup_socat)
 
     # hvc0 (virtio-console) instead of ttyS0 (16550A): the UART transfers
     # output byte-at-a-time through port IO + per-byte interrupts, which
@@ -545,9 +659,9 @@ pkgs.writeShellApplication {
     #
     # -display none (not -nographic): we wire stdio explicitly via the mux
     # chardev; -nographic assumes a single serial-on-stdio and conflicts.
-    # Two serials are kept so the kernel `console=ttyS1` resolves: ttyS0=null
-    # (unused now that the tool is on hvc0), ttyS1 -> kernel.log. Without
-    # ttyS1 present the console falls back to hvc0 and a getty grabs it.
+    # On x86, two serials are kept so `console=ttyS1` resolves: ttyS0=null and
+    # ttyS1 -> kernel.log. ARM's virt machine instead routes its one PL011
+    # `ttyAMA0` console to kernel.log.
     #
     # Console output pump. QEMU's virtconsole frontend silently DROPS guest
     # output when the host-side chardev write would block (EAGAIN) - console
@@ -562,8 +676,9 @@ pkgs.writeShellApplication {
     # unaffected. The pipeline is foreground: when QEMU exits, the pipe
     # closes, EOF drains the tail, pv exits, and pipefail propagates QEMU's
     # status - no FIFO, no background job, no cleanup.
-    qemu-system-${arch} \
-      "''${KVM_ARGS[@]}" \
+      qemu-system-${arch} \
+      "''${ACCEL_ARGS[@]}" \
+      "''${MACHINE_ARGS[@]}" \
       -m "$MEM" \
       -smp "$VCPU" \
       -kernel ${toplevel}/kernel \
@@ -576,15 +691,16 @@ pkgs.writeShellApplication {
       -device virtconsole,chardev=cons0,nr=0 \
       -chardev "socket,id=winsize,path=$WINSIZE_SOCK,server=on,wait=off" \
       -device virtserialport,chardev=winsize,name=llmjail.winsize \
-      -serial null \
-      -serial file:"$RUNDIR/kernel.log" \
+      "''${SUPERVISOR_VM_ARGS[@]}" \
+      "''${SERIAL_ARGS[@]}" \
       -no-reboot \
       -device virtio-rng-pci \
       -nic user,model=virtio-net-pci \
       -virtfs local,path=/nix/store,security_model=none,mount_tag=nix-store,readonly=on \
       -virtfs "local,path=$RUNDIR,security_model=none,mount_tag=envfs,readonly=on" \
-      "''${VIRTFS_ARGS[@]}" \
+      "''${SHARE_ARGS[@]}" \
       "''${DISK_ARGS[@]}" \
       | pv -q -B 64M
+    ''}
   '';
 }

--- a/lib/select-darwin-dns.awk
+++ b/lib/select-darwin-dns.awk
@@ -1,0 +1,81 @@
+# Select the first usable IPv4 resolver from scutil's ordinary DNS section.
+# Resolver metadata follows nameserver lines, so decide at block boundaries.
+
+function ipv4_address_p(address, octets, octet_count, octet_index) {
+  octet_count = split(address, octets, ".")
+  if (octet_count != 4) {
+    return 0
+  }
+
+  for (octet_index = 1; octet_index <= octet_count; octet_index++) {
+    if (octets[octet_index] !~ /^[0-9]+$/ || octets[octet_index] + 0 > 255) {
+      return 0
+    }
+  }
+
+  return 1
+}
+
+function finish_resolver() {
+  if (ordinary_section && in_resolver && !excluded && candidate != "") {
+    print candidate
+    selected = 1
+  }
+}
+
+$0 == "DNS configuration" {
+  finish_resolver()
+  if (selected) {
+    exit
+  }
+
+  ordinary_section = 1
+  in_resolver = 0
+  next
+}
+
+$0 ~ /^DNS configuration/ {
+  finish_resolver()
+  if (selected) {
+    exit
+  }
+
+  ordinary_section = 0
+  in_resolver = 0
+  next
+}
+
+$0 ~ /^resolver #[0-9]+$/ {
+  if (ordinary_section) {
+    finish_resolver()
+    if (selected) {
+      exit
+    }
+
+    in_resolver = 1
+    excluded = 0
+    candidate = ""
+  } else {
+    in_resolver = 0
+  }
+  next
+}
+
+ordinary_section && in_resolver {
+  if ($0 ~ /(Supplemental|Scoped)/) {
+    excluded = 1
+  }
+
+  if (candidate == "" &&
+      $1 ~ /^nameserver\[[0-9]+\]$/ &&
+      $2 == ":" &&
+      ipv4_address_p($3)) {
+    candidate = $3
+  }
+}
+
+END {
+  if (!selected) {
+    finish_resolver()
+  }
+}

--- a/lib/vz-runner/console-relay.swift
+++ b/lib/vz-runner/console-relay.swift
@@ -1,0 +1,86 @@
+import Darwin
+
+enum RelayTermination: Equatable {
+  case endOfFile
+  case failure(operation: String, code: Int32)
+}
+
+private func descriptorWouldBlock(_ code: Int32) -> Bool {
+  code == EAGAIN || code == EWOULDBLOCK
+}
+
+private func waitForDescriptor(_ descriptor: Int32, events: Int16) -> Int32? {
+  var state = pollfd(fd: descriptor, events: events, revents: 0)
+
+  while true {
+    state.revents = 0
+    let result = Darwin.poll(&state, 1, -1)
+    if result > 0 {
+      if state.revents & Int16(POLLNVAL) != 0 {
+        return EBADF
+      }
+      return nil
+    }
+    if result < 0 {
+      let code = errno
+      if code == EINTR {
+        continue
+      }
+      return code
+    }
+  }
+}
+
+@discardableResult
+func relayBytes(from source: Int32, to destination: Int32) -> RelayTermination {
+  var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+
+  while true {
+    let count = buffer.withUnsafeMutableBytes { bytes in
+      Darwin.read(source, bytes.baseAddress, bytes.count)
+    }
+    if count == 0 {
+      return .endOfFile
+    }
+    if count < 0 {
+      let code = errno
+      if code == EINTR {
+        continue
+      }
+      if descriptorWouldBlock(code) {
+        if let waitCode = waitForDescriptor(source, events: Int16(POLLIN)) {
+          return .failure(operation: "poll for read", code: waitCode)
+        }
+        continue
+      }
+      return .failure(operation: "read", code: code)
+    }
+
+    var offset = 0
+    while offset < count {
+      let written = buffer.withUnsafeBytes { bytes in
+        Darwin.write(
+          destination,
+          bytes.baseAddress!.advanced(by: offset),
+          count - offset)
+      }
+      if written > 0 {
+        offset += written
+      } else if written < 0 {
+        let code = errno
+        if code == EINTR {
+          continue
+        }
+        if descriptorWouldBlock(code) {
+          if let waitCode = waitForDescriptor(destination, events: Int16(POLLOUT)) {
+            return .failure(operation: "poll for write", code: waitCode)
+          }
+          continue
+        }
+        return .failure(operation: "write", code: code)
+      } else {
+        return .failure(operation: "write", code: EIO)
+      }
+    }
+  }
+}

--- a/lib/vz-runner/default.nix
+++ b/lib/vz-runner/default.nix
@@ -1,0 +1,41 @@
+{ pkgs }:
+
+pkgs.swiftPackages.stdenv.mkDerivation {
+  pname = "llm-jail-vz";
+  version = "1";
+  src = ./.;
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    pkgs.darwin.sigtool
+    pkgs.swift
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    swiftc -target arm64-apple-macosx13.0 \
+      -O -o llm-jail-vz console-relay.swift main.swift
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    swiftc -target arm64-apple-macosx13.0 \
+      -O -o console-relay-test console-relay.swift tests/main.swift
+    ./console-relay-test
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 llm-jail-vz $out/bin/llm-jail-vz
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    codesign --entitlements $src/llm-jail-vz.entitlements \
+      -f -s - $out/bin/llm-jail-vz
+  '';
+}

--- a/lib/vz-runner/llm-jail-vz.entitlements
+++ b/lib/vz-runner/llm-jail-vz.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.virtualization</key>
+  <true/>
+</dict>
+</plist>

--- a/lib/vz-runner/main.swift
+++ b/lib/vz-runner/main.swift
@@ -1,0 +1,345 @@
+import Darwin
+import Foundation
+import Virtualization
+
+struct Share {
+  let tag: String
+  let path: String
+  let readOnly: Bool
+}
+
+struct Options {
+  var cpuCount = 0
+  var memoryMiB = 0
+  var kernel = ""
+  var initrd = ""
+  var commandLineFile = ""
+  var disk: String?
+  var supervisorSocket: String?
+  var winsizeInput: String?
+  var shares: [Share] = []
+}
+
+func fail(_ message: String) -> Never {
+  FileHandle.standardError.write(Data("llm-jail-vz: \(message)\n".utf8))
+  exit(1)
+}
+
+func nextValue(_ arguments: [String], _ index: inout Int, _ option: String) -> String {
+  index += 1
+  guard index < arguments.count else { fail("\(option) requires a value") }
+  return arguments[index]
+}
+
+func parseShare(_ value: String) -> Share {
+  let fields = value.split(separator: ":", omittingEmptySubsequences: false)
+  guard fields.count == 3, !fields[0].isEmpty, !fields[1].isEmpty else {
+    fail("share must be TAG:PATH:MODE")
+  }
+  let mode = String(fields[2])
+  guard mode == "ro" || mode == "rw" else { fail("share mode must be ro or rw") }
+  return Share(tag: String(fields[0]), path: String(fields[1]), readOnly: mode == "ro")
+}
+
+func parseOptions() -> Options {
+  let arguments = Array(CommandLine.arguments.dropFirst())
+  var options = Options()
+  var index = 0
+  while index < arguments.count {
+    let option = arguments[index]
+    switch option {
+    case "--cpus":
+      options.cpuCount = Int(nextValue(arguments, &index, option)) ?? 0
+    case "--memory":
+      options.memoryMiB = Int(nextValue(arguments, &index, option)) ?? 0
+    case "--kernel":
+      options.kernel = nextValue(arguments, &index, option)
+    case "--initrd":
+      options.initrd = nextValue(arguments, &index, option)
+    case "--cmdline-file":
+      options.commandLineFile = nextValue(arguments, &index, option)
+    case "--disk":
+      options.disk = nextValue(arguments, &index, option)
+    case "--share":
+      options.shares.append(parseShare(nextValue(arguments, &index, option)))
+    case "--supervisor-socket":
+      options.supervisorSocket = nextValue(arguments, &index, option)
+    case "--winsize-input":
+      options.winsizeInput = nextValue(arguments, &index, option)
+    default:
+      fail("unknown option \(option)")
+    }
+    index += 1
+  }
+  guard options.cpuCount > 0 else { fail("--cpus must be positive") }
+  guard options.memoryMiB > 0 else { fail("--memory must be positive") }
+  guard !options.kernel.isEmpty else { fail("--kernel is required") }
+  guard !options.initrd.isEmpty else { fail("--initrd is required") }
+  guard !options.commandLineFile.isEmpty else { fail("--cmdline-file is required") }
+  return options
+}
+
+func openForReading(_ path: String) -> FileHandle {
+  guard let handle = FileHandle(forReadingAtPath: path) else { fail("cannot read \(path)") }
+  return handle
+}
+
+func connectUnixSocket(_ path: String) -> (reading: FileHandle, writing: FileHandle) {
+  guard path.hasPrefix("/") else { fail("supervisor socket path must be absolute") }
+
+  let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+  guard descriptor >= 0 else {
+    fail("cannot create supervisor socket: \(String(cString: strerror(errno)))")
+  }
+
+  var address = sockaddr_un()
+  let pathBytes = Array(path.utf8) + [UInt8(0)]
+  let pathCapacity = MemoryLayout.size(ofValue: address.sun_path)
+  guard pathBytes.count <= pathCapacity else {
+    Darwin.close(descriptor)
+    fail("supervisor socket path is too long")
+  }
+
+  address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+  address.sun_family = sa_family_t(AF_UNIX)
+  withUnsafeMutableBytes(of: &address.sun_path) { destination in
+    destination.copyBytes(from: pathBytes)
+  }
+
+  let result = withUnsafePointer(to: &address) { pointer in
+    pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+      Darwin.connect(
+        descriptor,
+        socketAddress,
+        socklen_t(MemoryLayout<sockaddr_un>.size))
+    }
+  }
+  guard result == 0 else {
+    let code = errno
+    Darwin.close(descriptor)
+    fail("cannot connect supervisor socket: \(String(cString: strerror(code)))")
+  }
+
+  let readingDescriptor = Darwin.dup(descriptor)
+  guard readingDescriptor >= 0 else {
+    let code = errno
+    Darwin.close(descriptor)
+    fail("cannot duplicate supervisor socket: \(String(cString: strerror(code)))")
+  }
+  let writingDescriptor = Darwin.dup(descriptor)
+  guard writingDescriptor >= 0 else {
+    let code = errno
+    Darwin.close(readingDescriptor)
+    Darwin.close(descriptor)
+    fail("cannot duplicate supervisor socket: \(String(cString: strerror(code)))")
+  }
+  Darwin.close(descriptor)
+
+  return (
+    FileHandle(fileDescriptor: readingDescriptor, closeOnDealloc: true),
+    FileHandle(fileDescriptor: writingDescriptor, closeOnDealloc: true))
+}
+
+func serialPort(reading: FileHandle?, writing: FileHandle?) -> VZSerialPortConfiguration {
+  let port = VZVirtioConsoleDeviceSerialPortConfiguration()
+  port.attachment = VZFileHandleSerialPortAttachment(
+    fileHandleForReading: reading,
+    fileHandleForWriting: writing)
+  return port
+}
+
+final class ConsoleRelay {
+  // Virtualization.framework transfers serial attachments to an XPC process
+  // outside this runner's process group. Keep the host terminal here so job
+  // control can suspend all terminal access during a trusted host prompt.
+  private let guestInput = Pipe()
+  private let guestOutput = Pipe()
+  private var inputThread: Thread?
+  private var outputThread: Thread?
+
+  var guestReadingHandle: FileHandle {
+    guestInput.fileHandleForReading
+  }
+
+  var guestWritingHandle: FileHandle {
+    guestOutput.fileHandleForWriting
+  }
+
+  func start(onFailure: @escaping (String) -> Void) {
+    let guestInputDescriptor = guestInput.fileHandleForWriting.fileDescriptor
+    let guestOutputDescriptor = guestOutput.fileHandleForReading.fileDescriptor
+    let inputThread = Thread {
+      switch relayBytes(from: STDIN_FILENO, to: guestInputDescriptor) {
+      case .endOfFile:
+        onFailure("console input closed")
+      case .failure(let operation, let code):
+        onFailure(
+          "console input relay failed during \(operation): "
+          + String(cString: strerror(code)))
+      }
+    }
+    let outputThread = Thread {
+      if case .failure(let operation, let code) =
+          relayBytes(from: guestOutputDescriptor, to: STDOUT_FILENO) {
+        onFailure(
+          "console output relay failed during \(operation): "
+          + String(cString: strerror(code)))
+      }
+    }
+
+    inputThread.name = "llm-jail-vz-console-input"
+    outputThread.name = "llm-jail-vz-console-output"
+    self.inputThread = inputThread
+    self.outputThread = outputThread
+    inputThread.start()
+    outputThread.start()
+  }
+}
+
+let options = parseOptions()
+let fileManager = FileManager.default
+for path in [options.kernel, options.initrd, options.commandLineFile] {
+  guard fileManager.fileExists(atPath: path) else { fail("file not found: \(path)") }
+}
+for share in options.shares {
+  var isDirectory: ObjCBool = false
+  guard fileManager.fileExists(atPath: share.path, isDirectory: &isDirectory),
+        isDirectory.boolValue else {
+    fail("shared directory not found: \(share.path)")
+  }
+}
+
+let commandLine: String
+do {
+  commandLine = try String(contentsOfFile: options.commandLineFile, encoding: .utf8)
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+} catch {
+  fail("cannot read kernel command line: \(error.localizedDescription)")
+}
+
+let configuration = VZVirtualMachineConfiguration()
+configuration.cpuCount = options.cpuCount
+configuration.memorySize = UInt64(options.memoryMiB) * 1024 * 1024
+
+let bootLoader = VZLinuxBootLoader(kernelURL: URL(fileURLWithPath: options.kernel))
+bootLoader.initialRamdiskURL = URL(fileURLWithPath: options.initrd)
+bootLoader.commandLine = commandLine
+configuration.bootLoader = bootLoader
+
+configuration.directorySharingDevices = options.shares.map { share in
+  let device = VZVirtioFileSystemDeviceConfiguration(tag: share.tag)
+  device.share = VZSingleDirectoryShare(
+    directory: VZSharedDirectory(
+      url: URL(fileURLWithPath: share.path),
+      readOnly: share.readOnly))
+  return device
+}
+
+if let disk = options.disk {
+  do {
+    let attachment = try VZDiskImageStorageDeviceAttachment(
+      url: URL(fileURLWithPath: disk),
+      readOnly: false,
+      cachingMode: .automatic,
+      synchronizationMode: .fsync)
+    configuration.storageDevices = [VZVirtioBlockDeviceConfiguration(attachment: attachment)]
+  } catch {
+    fail("cannot attach disk: \(error.localizedDescription)")
+  }
+}
+
+let network = VZVirtioNetworkDeviceConfiguration()
+network.attachment = VZNATNetworkDeviceAttachment()
+configuration.networkDevices = [network]
+configuration.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
+
+let consoleRelay = ConsoleRelay()
+var serialPorts: [VZSerialPortConfiguration] = [
+  serialPort(
+    reading: consoleRelay.guestReadingHandle,
+    writing: consoleRelay.guestWritingHandle)
+]
+if let socket = options.supervisorSocket {
+  let handles = connectUnixSocket(socket)
+  serialPorts.append(serialPort(reading: handles.reading, writing: handles.writing))
+}
+if let input = options.winsizeInput {
+  serialPorts.append(serialPort(reading: openForReading(input), writing: nil))
+}
+configuration.serialPorts = serialPorts
+
+do {
+  try configuration.validate()
+} catch {
+  fail("invalid VM configuration: \(error.localizedDescription)")
+}
+
+enum Terminal {
+  static var saved: termios?
+
+  static func makeRaw() {
+    guard isatty(STDIN_FILENO) == 1 else { return }
+    var current = termios()
+    guard tcgetattr(STDIN_FILENO, &current) == 0 else { return }
+    saved = current
+    cfmakeraw(&current)
+    tcsetattr(STDIN_FILENO, TCSANOW, &current)
+  }
+
+  static func restore() {
+    guard var previous = saved else { return }
+    tcsetattr(STDIN_FILENO, TCSANOW, &previous)
+    saved = nil
+  }
+}
+
+final class Delegate: NSObject, VZVirtualMachineDelegate {
+  func guestDidStop(_ virtualMachine: VZVirtualMachine) {
+    Terminal.restore()
+    exit(0)
+  }
+
+  func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
+    Terminal.restore()
+    fail("guest stopped: \(error.localizedDescription)")
+  }
+}
+
+let queue = DispatchQueue(label: "org.llm-jail.vz")
+let virtualMachine = VZVirtualMachine(configuration: configuration, queue: queue)
+let delegate = Delegate()
+virtualMachine.delegate = delegate
+Terminal.makeRaw()
+
+var signalSources: [DispatchSourceSignal] = []
+signal(SIGPIPE, SIG_IGN)
+for signalNumber in [SIGINT, SIGTERM] {
+  signal(signalNumber, SIG_IGN)
+  let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .main)
+  source.setEventHandler {
+    queue.async {
+      virtualMachine.stop { _ in
+        Terminal.restore()
+        exit(0)
+      }
+    }
+  }
+  source.resume()
+  signalSources.append(source)
+}
+
+consoleRelay.start { message in
+  DispatchQueue.main.async {
+    Terminal.restore()
+    fail(message)
+  }
+}
+queue.async {
+  virtualMachine.start { result in
+    if case .failure(let error) = result {
+      Terminal.restore()
+      fail("cannot start VM: \(error.localizedDescription)")
+    }
+  }
+}
+dispatchMain()

--- a/lib/vz-runner/tests/main.swift
+++ b/lib/vz-runner/tests/main.swift
@@ -1,0 +1,152 @@
+import Darwin
+import Dispatch
+import Foundation
+
+func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+  guard condition() else {
+    FileHandle.standardError.write(Data("console-relay-test: \(message)\n".utf8))
+    exit(1)
+  }
+}
+
+func makePipe() -> (reading: Int32, writing: Int32) {
+  var descriptors = [Int32](repeating: -1, count: 2)
+  require(Darwin.pipe(&descriptors) == 0, "cannot create pipe")
+  return (descriptors[0], descriptors[1])
+}
+
+func setNonblocking(_ descriptor: Int32) {
+  let flags = fcntl(descriptor, F_GETFL)
+  require(flags >= 0, "cannot read descriptor flags")
+  require(fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0,
+          "cannot set descriptor nonblocking")
+}
+
+final class RelayTerminationBox {
+  private let lock = NSLock()
+  private var termination: RelayTermination?
+
+  func store(_ value: RelayTermination) {
+    lock.lock()
+    termination = value
+    lock.unlock()
+  }
+
+  func load() -> RelayTermination? {
+    lock.lock()
+    defer { lock.unlock() }
+    return termination
+  }
+}
+
+func testDelayedNonblockingInput() {
+  let source = makePipe()
+  let destination = makePipe()
+  let completion = DispatchSemaphore(value: 0)
+  let termination = RelayTerminationBox()
+
+  setNonblocking(source.reading)
+  Thread {
+    termination.store(relayBytes(from: source.reading, to: destination.writing))
+    completion.signal()
+  }.start()
+
+  require(completion.wait(timeout: .now() + .milliseconds(100)) == .timedOut,
+          "relay exited while nonblocking input was temporarily empty")
+
+  var expected: UInt8 = 0x6b
+  require(Darwin.write(source.writing, &expected, 1) == 1,
+          "cannot write delayed input")
+
+  var ready = pollfd(fd: destination.reading, events: Int16(POLLIN), revents: 0)
+  require(Darwin.poll(&ready, 1, 1000) == 1,
+          "relay did not forward delayed input")
+
+  var actual: UInt8 = 0
+  require(Darwin.read(destination.reading, &actual, 1) == 1,
+          "cannot read relayed input")
+  require(actual == expected, "relay changed delayed input")
+
+  Darwin.close(source.writing)
+  require(completion.wait(timeout: .now() + .seconds(1)) == .success,
+          "relay did not stop at end of input")
+  require(termination.load() == .endOfFile,
+          "input relay did not report end of input")
+
+  Darwin.close(source.reading)
+  Darwin.close(destination.reading)
+  Darwin.close(destination.writing)
+}
+
+func fillNonblockingPipe(_ descriptor: Int32) -> Int {
+  setNonblocking(descriptor)
+  let buffer = [UInt8](repeating: 0x66, count: 4096)
+  var total = 0
+
+  while true {
+    let written = buffer.withUnsafeBytes { bytes in
+      Darwin.write(descriptor, bytes.baseAddress, bytes.count)
+    }
+    if written > 0 {
+      total += written
+      continue
+    }
+    if written < 0 && (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return total
+    }
+    require(false, "cannot fill nonblocking pipe")
+  }
+}
+
+func testDelayedNonblockingOutput() {
+  let source = makePipe()
+  let destination = makePipe()
+  let completion = DispatchSemaphore(value: 0)
+  let termination = RelayTerminationBox()
+  let fillerCount = fillNonblockingPipe(destination.writing)
+  require(fillerCount > 0, "nonblocking output pipe accepted no filler")
+
+  var expected: UInt8 = 0x6b
+  require(Darwin.write(source.writing, &expected, 1) == 1,
+          "cannot write source byte")
+  Darwin.close(source.writing)
+
+  Thread {
+    termination.store(relayBytes(from: source.reading, to: destination.writing))
+    completion.signal()
+  }.start()
+
+  require(completion.wait(timeout: .now() + .milliseconds(100)) == .timedOut,
+          "relay exited while nonblocking output was temporarily full")
+
+  var remaining = fillerCount
+  var buffer = [UInt8](repeating: 0, count: 4096)
+  while remaining > 0 {
+    let count = buffer.withUnsafeMutableBytes { bytes in
+      Darwin.read(destination.reading, bytes.baseAddress, min(bytes.count, remaining))
+    }
+    require(count > 0, "cannot drain output pipe")
+    remaining -= count
+  }
+
+  var ready = pollfd(fd: destination.reading, events: Int16(POLLIN), revents: 0)
+  require(Darwin.poll(&ready, 1, 1000) == 1,
+          "relay did not resume after output became writable")
+
+  var actual: UInt8 = 0
+  require(Darwin.read(destination.reading, &actual, 1) == 1,
+          "cannot read relayed output")
+  require(actual == expected, "relay changed delayed output")
+  require(completion.wait(timeout: .now() + .seconds(1)) == .success,
+          "output relay did not stop at end of input")
+  require(termination.load() == .endOfFile,
+          "output relay did not report end of input")
+
+  Darwin.close(source.reading)
+  Darwin.close(destination.reading)
+  Darwin.close(destination.writing)
+}
+
+signal(SIGPIPE, SIG_IGN)
+testDelayedNonblockingInput()
+testDelayedNonblockingOutput()

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,7 +7,10 @@ let
 
       nodes.machine = { lib, ... }: {
         imports = [ guestModule ];
-        _module.args = { inherit nixpkgs nixpkgs-rolling claude-code codex-cli copilot-cli opencode omp autolith pi-coding-agent; };
+        _module.args = {
+          hostBackend = "qemu";
+          inherit nixpkgs nixpkgs-rolling claude-code codex-cli copilot-cli opencode omp autolith pi-coding-agent;
+        };
         # Override 9p filesystem entries from common.nix - the test framework
         # provides its own root and /nix/store via virtualisation options.
         fileSystems."/.nix-lower/store" = lib.mkForce {
@@ -21,6 +24,7 @@ let
           options = [ "size=10M" ];
         };
         boot.initrd.postMountCommands = lib.mkForce "";
+        boot.kernelParams = lib.mkAfter [ "llmjail.user_uid=501" ];
 
         # Provide mock envfs contents for the mounts service
         systemd.tmpfiles.rules = [
@@ -72,10 +76,18 @@ let
             machine.succeed("which curl")
             machine.succeed("which ssh")
 
+        with subtest("no supervisor protocol client is installed"):
+            machine.fail("command -v llm-jail-supervisor")
+
         with subtest("user account is configured"):
             machine.succeed("id user")
+            machine.succeed("test $(id -u user) -eq 501")
             machine.succeed("test -d /home/user")
             machine.succeed("getent passwd user | grep -q /home/user")
+
+        with subtest("supervisor device permissions are narrow"):
+            machine.succeed("id -nG user | grep -qw dialout")
+            machine.succeed("grep -q 'llmjail.supervisor.*GROUP:=\"dialout\".*MODE:=\"0660\"' /etc/udev/rules.d/99-local.rules")
 
         with subtest("nix has flakes enabled"):
             machine.succeed("nix --version")
@@ -94,7 +106,10 @@ let
 
     nodes.machine = { lib, ... }: {
       imports = [ ../guests/claude.nix ];
-      _module.args = { inherit nixpkgs nixpkgs-rolling claude-code codex-cli; };
+      _module.args = {
+        hostBackend = "qemu";
+        inherit nixpkgs nixpkgs-rolling claude-code codex-cli;
+      };
 
       fileSystems."/.nix-lower/store" = lib.mkForce {
         device = "tmpfs";
@@ -190,7 +205,7 @@ in
 
   net-filter-smoke = netFilterTest;
 }
-// pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isx86_64 {
+// pkgs.lib.optionalAttrs (autolith != null) {
   autolith-smoke = mkSmokeTest {
     name = "autolith";
     guestModule = ../guests/autolith.nix;

--- a/tests/fixtures/scutil-dns-no-ordinary-ipv4.txt
+++ b/tests/fixtures/scutil-dns-no-ordinary-ipv4.txt
@@ -1,0 +1,19 @@
+DNS configuration
+
+resolver #1
+  nameserver[0] : 100.100.100.100
+  flags    : Supplemental, Request A records
+  reach    : 0x00000003 (Reachable,Transient Connection)
+
+resolver #2
+  nameserver[0] : 2001:db8::53
+  nameserver[1] : 2001:db8::54
+  flags    : Request AAAA records
+  reach    : 0x00000002 (Reachable)
+
+DNS configuration (for scoped queries)
+
+resolver #1
+  nameserver[0] : 192.0.2.1
+  flags    : Scoped, Request A records
+  reach    : 0x00000002 (Reachable)

--- a/tests/fixtures/scutil-dns-tailscale.txt
+++ b/tests/fixtures/scutil-dns-tailscale.txt
@@ -1,0 +1,28 @@
+DNS configuration
+
+resolver #1
+  search domain[0] : tailnet.invalid
+  nameserver[0] : 100.100.100.100
+  nameserver[1] : fd7a:115c:a1e0::53
+  if_index : 7 (utun0)
+  flags    : Supplemental, Request A records, Request AAAA records
+  reach    : 0x00000003 (Reachable,Transient Connection)
+  order    : 101600
+
+resolver #2
+  nameserver[0] : 2001:db8::53
+  nameserver[1] : 2001:db8::54
+  nameserver[2] : 192.0.2.53
+  nameserver[3] : 192.0.2.54
+  if_index : 8 (en0)
+  flags    : Request A records, Request AAAA records
+  reach    : 0x00000002 (Reachable)
+  order    : 200000
+
+DNS configuration (for scoped queries)
+
+resolver #1
+  nameserver[0] : 192.0.2.1
+  if_index : 9 (en1)
+  flags    : Scoped, Request A records
+  reach    : 0x00000002 (Reachable)

--- a/tools.nix
+++ b/tools.nix
@@ -72,7 +72,7 @@
   };
   autolith = {
     guestModule = ./guests/autolith.nix;
-    systems = [ "x86_64-linux" ];
+    systems = [ "x86_64-linux" "aarch64-linux" ];
     defaults = {
       mem = 4096;
       vcpu = 2;


### PR DESCRIPTION
## Summary

This change adds an `aarch64-darwin` target for Apple Silicon macOS hosts.

Darwin hosts run an `aarch64-linux` NixOS guest through the Virtualization.framework (VZ) backend. Linux hosts continue to use the QEMU backend with KVM or TCG.

Darwin exposes the Claude and shell runners. It also exposes Autolith when the input supplies an `aarch64-linux` Autolith package.

## Reason for the change

Before this change, llm-jail required a Linux host.

The VZ backend extends the same NixOS guest design. The guest selects the correct console, directory-share, DNS, and terminal-size adapters for each host backend.

## How it works

1. The flake maps an `aarch64-darwin` host to an `aarch64-linux` guest.
2. Nix uses a Linux builder or binary cache to get the guest closure.
3. A small Swift launcher loads the NixOS kernel and initrd directly.
4. The Nix build signs the launcher with the virtualization entitlement.
5. The launcher configures CPU count, memory, NAT, entropy, VirtioFS shares, and an optional ext4 disk.
6. The launcher relays bytes between the host terminal and guest console `/dev/hvc0`.
7. It restores the host terminal after shutdown, startup failure, relay failure, `SIGINT`, or `SIGTERM`.
8. A separate serial device sends terminal dimensions to the guest.
9. The guest applies each valid dimension change to `/dev/hvc0`.
10. The guest starts the common mount, network-filter, terminal-size, and tool services.
11. A VZ resolver service configures guest DNS before the network filter starts.

The Swift launcher keeps the host terminal in its process. It does not give the host terminal directly to the VZ service.

This design lets host job control suspend guest terminal access during a trusted permission prompt.

## Directory shares and Nix store

The VZ backend uses VirtioFS. The QEMU backend continues to use 9p.

The VZ launcher marks each read-only share as read-only in the host configuration. The guest also mounts that share as read-only.

The host `/nix/store` share is the read-only lower layer of a guest overlay. Tmpfs provides the guest write layer by default.

The `--store-disk` option uses a sparse ext4 image instead. The runner deletes this image when the virtual machine stops.

## DNS and network filter

The Darwin host reads its DNS configuration with `scutil --dns`.

The selector returns the first valid IPv4 server from the ordinary DNS section. It does not select Supplemental or Scoped resolver blocks.

For example, the selector does not use a Tailscale Supplemental resolver.

If the selector finds no valid address, the guest reads the first DNS server from its DHCP lease.

dnsmasq forwards only queries for domains in the current allowlist. Only root processes can query the upstream DNS server through the firewall.

After a successful response, dnsmasq adds the response IPv4 addresses to the firewall allowlist. The firewall permits HTTP and HTTPS only to these addresses.

The network-filter service reports ready only after dnsmasq creates its process ID file.

## Supervisor transport

Both host backends support the new `--supervisor-socket` option.

The host listener must create the Unix stream socket before llm-jail starts. The runner requires an absolute socket path.

The backend connects this socket to a private guest serial device. The guest receives only the device path through `LLMJAIL_SUPERVISOR_DEVICE`.

QEMU uses `/dev/virtio-ports/llmjail.supervisor`. VZ uses `/dev/hvc1`.

The guest does not receive the host socket path. Without this option, the guest has no supervisor device or supervisor environment variable.

This connection transfers an unstructured byte stream only. llm-jail defines no message boundaries, request operations, or security policy.

The host listener must define message boundaries, validate requests, authorize operations, and set resource limits. It must keep credentials out of responses.

The guest user accesses the device through the `dialout` group. The device mode is `0660`.

## Security properties

The guest has a separate Linux kernel and process space.

The host runner shares the Nix store, runtime files, workspace, tool state, and user-selected extra directories.

The VZ host configuration enforces the read-only state of each read-only share.

The tool-state directory is always writable. The workspace is writable by default. The `--immutable` option makes only the workspace read-only.

The guest, agent, writable shares, and all supervisor bytes remain untrusted. The agent can change all writable shares.

The host runner, virtual machine process, and optional supervisor listener remain trusted.

The default network filter remains active unless the user selects `--no-net-filter`.

The guest has no access to unselected host directories or the host process space.

## Other compatibility changes

The guest can use a host UID of 500 or greater when no guest account has that UID. This supports Darwin UIDs such as 501.

The guest ignores UID values below 500 and keeps its UID collision check.

Autolith now supports an `aarch64-linux` guest.

For an `aarch64-linux` guest, QEMU uses the ARM `virt` machine and the `ttyAMA0` kernel console.

The Darwin shell runner uses guest zsh or bash. The Linux guest cannot execute Darwin host binaries.

The store overlay hides a top-level `.lock` file only when that file is empty and has mode `0600`.

If the storage layer contains a Nix database, the guest reuses it. The guest then registers the current closure.

A network-filter restart removes the old dnsmasq process and nftables table before the tool starts.

## Requirements and limits

- The host must use Apple Silicon.
- The host must provide Virtualization.framework.
- This change does not add `x86_64-darwin` support.
- The host needs a Linux builder or binary cache for the `aarch64-linux` guest closure.
- The current Nix Swift toolchain sets a macOS 14 deployment target.
- Darwin exposes Claude and shell.
- Darwin exposes Autolith only when the input supplies its `aarch64-linux` package.
- DNS selection supports ordinary IPv4 resolvers only.
- The supervisor connection supplies byte transport only.

## Test coverage

The VZ package runs Swift tests for delayed nonblocking input and output. These tests verify byte preservation and end-of-file completion.

DNS fixtures verify that the selector ignores a Tailscale Supplemental resolver. They also verify ordinary IPv4 resolver selection.

A second fixture verifies an empty result when no ordinary IPv4 resolver exists.

Darwin flake checks build the Claude and shell runners. They also build Autolith when its `aarch64-linux` package exists.

NixOS smoke tests set the guest UID to 501. They verify supervisor device permissions, `dialout` membership, and the absence of a supervisor protocol client.

The repository has no automated end-to-end VZ boot test. The current GitHub workflow uses an Ubuntu host only.